### PR TITLE
Disable ENCODE_FRAMEDUMPS explicitly on OS X.

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -243,7 +243,7 @@ def make_dolphin_osx_build(mode='normal'):
                            description="mkbuilddir",
                            descriptionDone="mkbuilddir"))
 
-    f.addStep(ShellCommand(command=["cmake", ".."],
+    f.addStep(ShellCommand(command=["cmake", "-DENCODE_FRAMEDUMPS=OFF", ".."],
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",


### PR DESCRIPTION
My PR1435 changes the default to pick up user-installed libraries on OS
X (preferring system libraries rather than using them exclusively),
which is sane for general builds.  But linking ffmpeg, even statically,
adds like 14MB to the binary size.  Until someone figures out how to
trim that down, disable it on the buildbot.
