### PR TITLE
Update Android Native API level to 18.

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -428,7 +428,7 @@ def make_android_package(mode='normal'):
                            description="mkbuilddir",
                            descriptionDone="mkbuilddir"))
 
-    f.addStep(ShellCommand(command=["cmake", "-DANDROID=True", "-DANDROID_NATIVE_API_LEVEL=android-14",
+    f.addStep(ShellCommand(command=["cmake", "-DANDROID=True", "-DANDROID_NATIVE_API_LEVEL=android-18",
                                     "-DGIT_EXECUTABLE=/usr/bin/git",
                                     "-DCMAKE_TOOLCHAIN_FILE=../Source/Android/android.toolchain.cmake", ".."],
                            env={ "ANDROID_NDK": "/home/buildbot/ndk" },


### PR DESCRIPTION
We require Android 4.3 minimum now, which is API level 18.