### PR TITLE
Extend lint rules

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -725,6 +725,12 @@ def make_lint():
                            description="trailing ws",
                            descriptionDone="trailing ws",
                            haltOnFailure=False))
+    f.addStep(ShellCommand(command='r=$(find Source -name "*.cpp" -o -name "*.h" | xargs -i sh -c \'[ $(tail -n1 {}|wc -l) == 1 ] || echo {}\''
+                                   'if ! [ -z "$r" ]; then echo "$r"; exit 1; else echo "OK"; fi',
+                           logEnviron=False,
+                           description="no newline at EOF",
+                           descriptionDone="no newline at EOF",
+                           haltOnFailure=False))
     return f
 
 

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -713,13 +713,13 @@ def make_lint():
     f = BuildFactory()
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
-    f.addStep(ShellCommand(command='r=$(Tools/check-includes.py $(find Source/Core -name "*.cpp" -o -name "*.h") 2>&1 >/dev/null);'
+    f.addStep(ShellCommand(command='r=$(Tools/check-includes.py $(find Source -name "*.cpp" -o -name "*.h") 2>&1 >/dev/null);'
                                    'if ! [ -z "$r" ]; then echo "$r"; exit 1; else echo "OK"; fi',
                            logEnviron=False,
                            description="includes",
                            descriptionDone="includes",
                            haltOnFailure=False))
-    f.addStep(ShellCommand(command='r=$(find Source/Core -name "*.cpp" -o -name "*.h" | xargs egrep -n "\\s+$");'
+    f.addStep(ShellCommand(command='r=$(find Source -name "*.cpp" -o -name "*.h" | xargs egrep -n "\\s+$");'
                                    'if ! [ -z "$r" ]; then echo "$r"; exit 1; else echo "OK"; fi',
                            logEnviron=False,
                            description="trailing ws",


### PR DESCRIPTION
Depends on https://github.com/dolphin-emu/dolphin/pull/2161.

Could `xargs -i sh -c '[ $(tail -n1 {}|wc -l) == 1 ] || echo {}'` be done in an easier way?