### PR TITLE
central: build PRs even if mergeable=None

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -86,7 +86,8 @@ class PullRequestBuilder:
                 events.dispatcher.dispatch('prbuilder', status_evt)
                 continue
 
-            if not pr['mergeable']:
+            # mergeable can be None!
+            if pr['mergeable'] is False:
                 status_evt = events.PullRequestBuildStatus(repo, head_sha,
                         'default', 'failure', '',
                         'PR cannot be merged, please rebase.')


### PR DESCRIPTION
No idea what it means but GitHub sometimes delivers events with mergeable_state="unknown" and mergeable=None. Checking explicitly for False should fix the randomly occurring problem that central marks a PR as unmergeable even though GitHub says it is mergeable.