### PR TITLE
central: add rebuild command for IRC

### DIFF
--- a/central/config.yml
+++ b/central/config.yml
@@ -6,6 +6,7 @@ irc:
     channels:
         - "#dolphin-dev"
         - "#dolphin-test"
+    rebuild_repo: dolphin-emu/dolphin
 
 web:
     external_url: https://central.dolphin-emu.org

--- a/central/config.yml
+++ b/central/config.yml
@@ -6,8 +6,6 @@ irc:
     channels:
         - "#dolphin-dev"
         - "#dolphin-test"
-    trusted_users:
-        - delroth
 
 web:
     external_url: https://central.dolphin-emu.org


### PR DESCRIPTION
To avoid unimportant GitHub notifications, add an IRC command `irrawaddy rebuild pr 1234` similar to the GitHub command `@dolphin-emu-bot rebuild`. Requires op ~~or voice~~ as authentication.

Suggested by @mathieui. Untested.