### PR TITLE
Exclude Test files from nightly OS X package

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -368,7 +368,7 @@ def make_dolphin_osx_build(mode="normal"):
 
     f.addStep(ShellCommand(command=["hdiutil", "create", "dolphin.dmg",
                                     "-format", "UDBZ",
-                                    "-srcfolder", "Binaries/", "-ov",
+                                    "-srcfolder", "Binaries/*.app", "-ov",
                                     "-volname", WithProperties("Dolphin %s-%s", "branchname", "shortrev")],
                            workdir="build/build",
                            logEnviron=False,


### PR DESCRIPTION
Currently some test files get included in the `.dmg` package generated for OS X nightly builds. This commit ensures that only app bundles will be included in the packaged dmg file.

This reduces the size of nightly `Dolphin.dmg` files from 6.4 Mo to 4.7 Mo,
by excluding the `Tests` directory and the `traversal_server` binary.

Fixes [issue 8084](https://dolp.in/i8084). @parlane I saw you are the owner of this issue, maybe you want to have a look?