### PR TITLE
Point Android PR uploads at the correct filename.

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -563,6 +563,7 @@ def make_android_package(mode="normal"):
                                descriptionDone="Gradle",
                                haltOnFailure=True))
 
+        source_filename = "Source/Android/app/build/outputs/apk/app-arm_64-release.apk"
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
         url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
 
@@ -574,10 +575,11 @@ def make_android_package(mode="normal"):
                                descriptionDone="Gradle",
                                haltOnFailure=True))
 
+        source_filename = "Source/Android/app/build/outputs/apk/app-arm_64-debug.apk"
         master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest.apk", "branchname")
         url = WithProperties("http://dl.dolphin-emu.org/prs/%s-dolphin-latest.apk", "branchname")
         
-    f.addStep(FileUpload(slavesrc="Source/Android/app/build/outputs/apk/app-arm_64-release.apk",
+    f.addStep(FileUpload(slavesrc=source_filename,
                              masterdest=master_filename,
                              url=url, keepstamp=True, mode=0644))
 


### PR DESCRIPTION
PRs are built as 'debug', so they have a different filename as a result. This should correct for that.