### PR TITLE
Add a status check for PRs including merge commits

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -91,19 +91,19 @@ class PullRequestBuilder:
                 events.dispatcher.dispatch('prbuilder', status_evt)
                 continue
 
-            if not trusted:
-                status_evt = events.PullRequestBuildStatus(repo, head_sha,
-                        'default', 'failure', '',
-                        'PR not built because %s is not auto-trusted.'
-                            % in_behalf_of)
-                events.dispatcher.dispatch('prbuilder', status_evt)
-                continue
-
             # mergeable can be None!
             if pr['mergeable'] is False:
                 status_evt = events.PullRequestBuildStatus(repo, head_sha,
                         'default', 'failure', '',
                         'PR cannot be merged, please rebase.')
+                events.dispatcher.dispatch('prbuilder', status_evt)
+                continue
+
+            if not trusted:
+                status_evt = events.PullRequestBuildStatus(repo, head_sha,
+                        'default', 'failure', '',
+                        'PR not built because %s is not auto-trusted.'
+                            % in_behalf_of)
                 events.dispatcher.dispatch('prbuilder', status_evt)
                 continue
 


### PR DESCRIPTION
Since we keep getting PRs with merge commits, and we keep replying to those "please rebase", why don't we simply automate this?

The first commit queries [the GitHub API for PR Commits](https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request) to see if any of the commits has more than one parent (which is most commonly a merge).
It does **not** check whether it is an actual "merge upstream/master" commit, so it might yield a (most likely very very small) number of false positives in case the PR itself used branches and merges for structuring - but I'm considering this number too small to support it at this point (even bigger stuff like NZHLE did not do this).
This check is run before the `trusted` check, since it simply checks what GitHub already knows and doesn't do any buildbot stuff or so. Trusted users know this anyways, its mostly the new developers not yet acquainted with how to do things around here that do upstream-merges instead.

The second commit is more or less a +/-0, but I think we can safely tell a non-trusted user that their PR cannot be merged, and they should rebase - even though GitHub already does this.
I can just drop that commit if we don't care enough about it.

Also, I barely speak Python, and I certainly don't have a setup where I can try this out; so this code is entirely **untested** (well, except for the `any(...)` block that ran through IDLE and Python Shell at least twice). But I believe the change is trivial enough to be made by my humble self without major screwups. 
