### PR TITLE
irrawaddy: replace goo.gl with dolp.in in issues

### DIFF
--- a/central/ircclient.py
+++ b/central/ircclient.py
@@ -86,7 +86,9 @@ class EventTarget(events.EventTarget):
     def handle_issue(self, evt):
         """Sends an IRC message notifying of a new issue update."""
         author = self.format_nickname(evt.author)
-        url = Tags.UnderlineBlue(utils.shorten_url(evt.url))
+        short_url = evt.url.replace('https://bugs.dolphin-emu.org/issues/',
+                                    'https://dolp.in/i')
+        url = Tags.UnderlineBlue(short_url)
         if evt.new:
             msg = 'Issue %d created: "%s" by %s - %s'
             msg = msg % (evt.issue, evt.title, author, url)


### PR DESCRIPTION
I’m not totally sure replace is the best thing to use here, if we are 100% sure the URL will always have that form we could use a substring instead.