### PR TITLE
Make issue update links point to specific comments

### DIFF
--- a/central/ircclient.py
+++ b/central/ircclient.py
@@ -88,6 +88,8 @@ class EventTarget(events.EventTarget):
         author = self.format_nickname(evt.author)
         short_url = evt.url.replace('https://bugs.dolphin-emu.org/issues/',
                                     'https://dolp.in/i')
+        if not evt.new:
+            short_url = '{}/{}'.format(short_url, evt.update)
         url = Tags.UnderlineBlue(short_url)
         if evt.new:
             msg = 'Issue %d created: "%s" by %s - %s'


### PR DESCRIPTION
Links sent by the irc bot should link directly to the specific updates. As the redirector already knows how to redirect those, we only have to change the url.

It _may_ be wrong in some cases as I remember the update number is 1 for the first non-imported comment, but it will still point to the right page anyway.
