### PR TITLE
Limit all unix slaves to max_builds=1

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -866,11 +866,11 @@ BuildmasterConfig = {
 
     "slaves": [
         BuildSlave("windows", BUILDSLAVES_PASSWORDS["windows"], max_builds=1),
-        BuildSlave("osx", BUILDSLAVES_PASSWORDS["osx"]),
-        BuildSlave("debian", BUILDSLAVES_PASSWORDS["debian"]),
-        BuildSlave("ubuntu", BUILDSLAVES_PASSWORDS["ubuntu"]),
+        BuildSlave("osx", BUILDSLAVES_PASSWORDS["osx"], max_builds=1),
+        BuildSlave("debian", BUILDSLAVES_PASSWORDS["debian"], max_builds=1),
+        BuildSlave("ubuntu", BUILDSLAVES_PASSWORDS["ubuntu"], max_builds=1),
         BuildSlave("arch64", BUILDSLAVES_PASSWORDS["arch64"]),
-        BuildSlave("freebsd", BUILDSLAVES_PASSWORDS["freebsd"]),
+        BuildSlave("freebsd", BUILDSLAVES_PASSWORDS["freebsd"], max_builds=1),
         BuildSlave("ec2-ubu64-nv", BUILDSLAVES_PASSWORDS["ec2-ubu64-nv"], keepalive_interval=60, max_builds=1),
         BuildSlave("ec2-win64-nv", BUILDSLAVES_PASSWORDS["ec2-win64-nv"], keepalive_interval=60, max_builds=1),
         BuildSlave("ec2-ubu64-indexer", BUILDSLAVES_PASSWORDS["ec2-ubu64-indexer"], keepalive_interval=60, max_builds=1),


### PR DESCRIPTION
They use ninja to build parallel internally, so there is no need to run
two build scripts at once.