### PR TITLE
central: add update number to shortened issue URLs

### DIFF
--- a/central/config.yml
+++ b/central/config.yml
@@ -60,6 +60,3 @@ fifoci:
 
 shortener:
     api_key: API_KEY
-
-redmine:
-    url: https://bugs.dolphin-emu.org/

--- a/central/events.py
+++ b/central/events.py
@@ -67,9 +67,9 @@ def IRCMessage(who : str, where : str, what : str, modes : str, direct : bool):
 
 @event('issue')
 def Issue(new : bool, update : int, issue : int, title : str,
-          author : str, url : str):
+          author : str):
     return { 'new': new, 'update': update, 'issue': issue, 'title': title,
-             'author': author, 'url': url }
+             'author': author }
 
 @event('raw_gh_hook')
 def RawGHHook(gh_type : str, raw : dict):

--- a/central/ircclient.py
+++ b/central/ircclient.py
@@ -86,13 +86,14 @@ class EventTarget(events.EventTarget):
     def handle_issue(self, evt):
         """Sends an IRC message notifying of a new issue update."""
         author = self.format_nickname(evt.author)
-        short_url = evt.url.replace('https://bugs.dolphin-emu.org/issues/',
-                                    'https://dolp.in/i')
-        url = Tags.UnderlineBlue(short_url)
         if evt.new:
+            short_url = 'https://dolp.in/i%d' % evt.issue
+            url = Tags.UnderlineBlue(short_url)
             msg = 'Issue %d created: "%s" by %s - %s'
             msg = msg % (evt.issue, evt.title, author, url)
         else:
+            short_url = 'https://dolp.in/i%d/%d' % (evt.issue, evt.update)
+            url = Tags.UnderlineBlue(short_url)
             msg = 'Update %d to issue %d ("%s") by %s - %s'
             msg = msg % (evt.update, evt.issue, evt.title, author, url)
         self.bot.say(msg)

--- a/central/redmine.py
+++ b/central/redmine.py
@@ -26,9 +26,8 @@ class Reactor(events.EventTarget):
             author = evt.raw.issue.author.login
         else:
             author = evt.raw.journal.author.login
-        url = '%sissues/%s' % (cfg.redmine.url, issue)
         events.dispatcher.dispatch('redmine',
-                events.Issue(new, update, issue, title, author, url))
+                events.Issue(new, update, issue, title, author))
 
 
 def start():


### PR DESCRIPTION
(This doesn't work for imported issues, but we're mostly getting new issues now anyways.)