### PR TITLE
Label Android builds as being for 64-bit ARM on download page

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -610,7 +610,7 @@ def make_android_package(mode="normal"):
                                          "HASH": WithProperties("%s", "revision"),
                                          "AUTHOR": WithProperties("%s", "author"),
                                          "DESCRIPTION": WithProperties("%s", "description"),
-                                         "TARGET_SYSTEM": "Android",
+                                         "TARGET_SYSTEM": "Android (ARM 64-bit)",
                                          "USER_OS_MATCHER": "android",
                                          "BUILD_URL": url,
                                      },


### PR DESCRIPTION
Not sure if this actually affects the download page, but if it does, this labeling is crucial for informing users  that they need a 64-bit device in order to run the Android build.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/sadm/57)

<!-- Reviewable:end -->
