### PR TITLE
Increase Android native API level to 21(Android 5.0)

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -552,7 +552,7 @@ def make_android_package(mode="normal"):
                            description="mkbuilddir",
                            descriptionDone="mkbuilddir"))
 
-    f.addStep(ShellCommand(command=["cmake", "-DANDROID=True", "-DANDROID_NATIVE_API_LEVEL=android-18",
+    f.addStep(ShellCommand(command=["cmake", "-DANDROID=True", "-DANDROID_NATIVE_API_LEVEL=android-21",
                                     "-DGIT_EXECUTABLE=/usr/bin/git",
                                     "-DANDROID_ABI=arm64-v8a",
                                     "-DANDROID_TOOLCHAIN_NAME=aarch64-linux-android-4.9",


### PR DESCRIPTION
It's already our minimum requirement and it is needed to support the KHR_create_context extension without defining everything ourselves.