### PR TITLE
Return the original URL if shortening fails

### DIFF
--- a/central/utils.py
+++ b/central/utils.py
@@ -24,14 +24,14 @@ def shorten_url(url):
                              data=json.dumps(data)).json()
     except Exception:
         logging.exception('URL shortening failed because of a network error')
-        return '<goo.gl network error>'
+        return url
 
     try:
         return result['id']
     except KeyError:
         logging.exception('URL shortening failed because of response: %s',
                           result)
-        return '<goo.gl invalid response>'
+        return url
 
 
 class DaemonThread(threading.Thread):


### PR DESCRIPTION
<irrawaddy> [dolphin-emu/dolphin] J﻿osJuice commented on #3763 (Always clear memory when booting): <goo.gl invalid response>

Long link is better than no link.

edit: stupid html tags
