### PR TITLE
Remove -DENCODE_FRAMEDUMPS=OFF flag from OSX

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -354,7 +354,7 @@ def make_dolphin_osx_build(mode="normal"):
                            description="mkbuilddir",
                            descriptionDone="mkbuilddir"))
 
-    f.addStep(ShellCommand(command=["cmake", "-DENCODE_FRAMEDUMPS=OFF", ".."],
+    f.addStep(ShellCommand(command=["cmake", ".."],
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",


### PR DESCRIPTION
Allows ffmpeg to properly be included in OSX builds