### PR TITLE
IRC: Ignore "comment edited/deleted" events

### DIFF
--- a/central/events.py
+++ b/central/events.py
@@ -96,9 +96,9 @@ def GHPullRequest(repo : str, author : str, action : str, id : int,
              'base_sha': base_sha, 'head_sha': head_sha }
 
 @event('gh_pull_request_comment')
-def GHPullRequestComment(repo : str, author : str, id : int, hash : str,
+def GHPullRequestComment(repo : str, author : str, action : str, id : int, hash : str,
                          url : str):
-    return { 'repo': repo, 'author': author, 'id': id, 'hash': hash,
+    return { 'repo': repo, 'author': author, 'action': action, 'id': id, 'hash': hash,
              'url': url }
 
 @event('gh_issue_comment')

--- a/central/github.py
+++ b/central/github.py
@@ -242,8 +242,8 @@ class GHHookEventParser(events.EventTarget):
         author = raw.sender.login
         repo = raw.repository.owner.login + '/' + raw.repository.name
         id = int(raw.issue.html_url.split('/')[-1])
-        return events.GHIssueComment(repo, author, id, raw.issue.title,
-                                     raw.comment.html_url, 
+        return events.GHIssueComment(repo, author, raw.action, id, raw.issue.title,
+                                     raw.comment.html_url,
                                      is_safe_author(author), raw.comment.body,
                                      raw)
 

--- a/central/ircclient.py
+++ b/central/ircclient.py
@@ -174,6 +174,8 @@ class EventTarget(events.EventTarget):
             Tags.UnderlineBlue(utils.shorten_url(evt.url))))
 
     def handle_gh_pull_request_comment(self, evt):
+        if evt.action != 'created':
+            return
         self.bot.say('[%s] %s commented on #%s %s: %s' % (
             Tags.UnderlinePink(evt.repo), self.format_nickname(evt.author),
             evt.id, evt.hash[:6],


### PR DESCRIPTION
This makes the IRC bot ignore PR comment edited or deleted events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/sadm/61)
<!-- Reviewable:end -->
