### PR TITLE
Handle GitHub comment actions

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -152,6 +152,8 @@ class ManualPullRequestListener(events.EventTarget):
             return
         if evt.repo not in cfg.github.maintain:
             return
+        if evt.action != 'created':
+            return
         self.builder.push(evt.author, evt.safe_author, evt.repo, evt.id)
 
 

--- a/central/events.py
+++ b/central/events.py
@@ -135,10 +135,11 @@ def GHPullRequestComment(repo: str, author: str, action: str, id: int, hash:
 
 
 @event('gh_issue_comment')
-def GHIssueComment(repo: str, author: str, id: int, title: str, url: str,
+def GHIssueComment(repo: str, author: str, action: str, id: int, title: str, url: str,
                    safe_author: bool, body: str, raw: dict):
     return {'repo': repo,
             'author': author,
+            'action': action,
             'id': id,
             'title': title,
             'url': url,

--- a/central/github.py
+++ b/central/github.py
@@ -251,7 +251,7 @@ class GHHookEventParser(events.EventTarget):
         repo = raw.repository.owner.login + '/' + raw.repository.name
         id = int(raw.issue.html_url.split('/')[-1])
         return events.GHIssueComment(
-            repo, author, id, raw.issue.title, raw.comment.html_url,
+            repo, author, raw.action, id, raw.issue.title, raw.comment.html_url,
             is_safe_author(author), raw.comment.body, raw)
 
     def convert_commit_comment_event(self, raw):

--- a/central/ircclient.py
+++ b/central/ircclient.py
@@ -209,9 +209,9 @@ class EventTarget(events.EventTarget):
     def handle_gh_issue_comment(self, evt):
         if evt.author == cfg.github.account.login:
             return
-        self.bot.say('[%s] %s commented on #%s (%s): %s' % (
+        self.bot.say('[%s] %s %s comment on #%s (%s): %s' % (
             Tags.UnderlinePink(evt.repo), self.format_nickname(evt.author),
-            evt.id, evt.title, Tags.UnderlineBlue(utils.shorten_url(evt.url))))
+            evt.action, evt.id, evt.title, Tags.UnderlineBlue(utils.shorten_url(evt.url))))
 
     def handle_gh_commit_comment(self, evt):
         self.bot.say('[%s] %s commented on commit %s: %s' % (


### PR DESCRIPTION
Apparently comments on pull requests are treated as issue comments, so the previous PR had no effect most of the time (even if it didn't break something…)

This is a more complete change to handle GitHub comment actions correctly:

- Rebuilds are only triggered when the comment is created. This should prevent duplicate rebuilds if someone creates the rebuild comment and then deletes it. (which I think is what is intended)

- The IRC comment messages now indicate the action correctly, instead of only showing "commented" even for deletions/edits.

(I double-checked this time and the event should be correct (verified with the recent events page), and hopefully I haven't missed anything)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/sadm/62)
<!-- Reviewable:end -->
