### PR TITLE
Buildbot: Update android build to the android studio 2.2 way.

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -460,29 +460,6 @@ def make_android_package(mode="normal"):
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
 
-    f.addStep(ShellCommand(command=["mkdir", "-p", "build-arm64"],
-                           logEnviron=False,
-                           description="mkbuilddir",
-                           descriptionDone="mkbuilddir"))
-
-    f.addStep(ShellCommand(command=["cmake", "-DANDROID=True", "-DANDROID_NATIVE_API_LEVEL=android-21",
-                                    "-DGIT_EXECUTABLE=/usr/bin/git",
-                                    "-DANDROID_ABI=arm64-v8a",
-                                    "-DANDROID_TOOLCHAIN_NAME=aarch64-linux-android-4.9",
-                                    "-DCMAKE_TOOLCHAIN_FILE=../Source/Android/android.toolchain.cmake",
-                                    "-DDISTRIBUTOR=dolphin-emu.org",
-                                    "-GNinja", ".."],
-                           workdir="build/build-arm64",
-                           description="configuring arm64",
-                           descriptionDone="configure arm64",
-                           haltOnFailure=True))
-
-    f.addStep(Compile(command=["ninja"],
-                      workdir="build/build-arm64",
-                      description="building arm64",
-                      descriptionDone="build arm64",
-                      haltOnFailure=True))
-
     if mode == "normal":
         f.addStep(ShellCommand(command="./gradlew assembleRelease "
                                        "-Pkeystore=$HOME/dolphin-release.keystore "
@@ -494,7 +471,7 @@ def make_android_package(mode="normal"):
                                descriptionDone="Gradle",
                                haltOnFailure=True))
 
-        source_filename = "Source/Android/app/build/outputs/apk/app-arm_64-release.apk"
+        source_filename = "Source/Android/app/build/outputs/apk/app-release.apk"
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
         url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
 
@@ -505,7 +482,7 @@ def make_android_package(mode="normal"):
                                descriptionDone="Gradle",
                                haltOnFailure=True))
 
-        source_filename = "Source/Android/app/build/outputs/apk/app-arm_64-debug.apk"
+        source_filename = "Source/Android/app/build/outputs/apk/app-debug.apk"
         master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest.apk", "branchname")
         url = WithProperties("http://dl.dolphin-emu.org/prs/%s-dolphin-latest.apk", "branchname")
 


### PR DESCRIPTION
CMake + ninja are now called by gradle, no need to call it ourself.

This must be merged together with https://github.com/dolphin-emu/dolphin/pull/4252