### PR TITLE
central/utils: handle empty url for shortener

### DIFF
--- a/central/utils.py
+++ b/central/utils.py
@@ -15,6 +15,8 @@ import time
 def shorten_url(url):
     """Minify a URL using goo.gl."""
     from config import cfg  # Cannot be done at toplevel - circular import.
+    if url == '':
+        return '<no url>'
     try:
         headers = {'Content-Type': 'application/json'}
         data = {'longUrl': url}


### PR DESCRIPTION
Gives the URL shortener a better response in the case of an empty URL.
