### PR TITLE
central: Skip PR reviews which have only one review comment

### DIFF
--- a/central/events.py
+++ b/central/events.py
@@ -125,7 +125,7 @@ def GHPullRequest(repo: str, author: str, action: str, id: int, title: str,
 
 @event('gh_pull_request_review')
 def GHPullRequestReview(repo: str, author: str, action: str, pr_id: int,
-                        pr_title: str, state: str, url: str):
+                        pr_title: str, state: str, url: str, comments: list):
     """This event is triggered when a GitHub review is submitted."""
     return {'repo': repo,
             'author': author,
@@ -133,7 +133,8 @@ def GHPullRequestReview(repo: str, author: str, action: str, pr_id: int,
             'pr_id': pr_id,
             'pr_title': pr_title,
             'state': state,
-            'url': url}
+            'url': url,
+            'comments': comments}
 
 @event('gh_pull_request_comment')
 def GHPullRequestComment(repo: str, author: str, action: str, id: int, hash:


### PR DESCRIPTION
GitHub sends a review event in addition to a review comment event when someone replies to an earlier comment or adds a single comment, even when they didn't really submit a pull request review. (This makes no sense to me, but that's how they designed their PR reviews.)

To prevent useless notifications, we skip any "review" which only has one comment, since there is already a comment notification for those.

Additionally, since we now have info on associated comments, we can show whether comments were posted for an approval review event.
