### PR TITLE
central: update link to buildbot /#/waterfall page

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -105,7 +105,7 @@ class PullRequestBuilder:
             for builder in cfg.buildbot.pr_builders:
                 status_evt = events.BuildStatus(
                     repo, head_sha, shortrev, builder, pr_id, False, True,
-                    cfg.buildbot.url + '/waterfall', 'Auto build in progress')
+                    cfg.buildbot.url + '/#/waterfall', 'Auto build in progress')
                 events.dispatcher.dispatch('prbuilder', status_evt)
 
             patch = requests.get('https://github.com/%s/pull/%d.patch' %


### PR DESCRIPTION
Since the upgrade, https://buildbot.dolphin-emu.org/waterfall returns a 404. The new location is https://buildbot.dolphin-emu.org/#/waterfall .