### PR TITLE
central: Minor fixes

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -105,7 +105,7 @@ class PullRequestBuilder:
             for builder in cfg.buildbot.pr_builders:
                 status_evt = events.BuildStatus(
                     repo, head_sha, shortrev, builder, pr_id, False, True,
-                    cfg.buildbot.url + '/waterfall', 'Auto build in progress')
+                    cfg.buildbot.url + '/#/waterfall', 'Auto build in progress')
                 events.dispatcher.dispatch('prbuilder', status_evt)
 
             patch = requests.get('https://github.com/%s/pull/%d.patch' %

--- a/central/ircclient.py
+++ b/central/ircclient.py
@@ -211,6 +211,9 @@ class EventTarget(events.EventTarget):
             evt.comments[0].created_at == evt.comments[0].updated_at:
             return
 
+        if evt.state == 'pending':
+            return
+
         if evt.action == 'submitted' and evt.state == 'approved':
             action = 'approved'
             if len(evt.comments) != 0:


### PR DESCRIPTION
* Fix the commit status link for pending builds.
* Remove a useless review notification. This is now required because GH has started sending out events for pending reviews.