### PR TITLE
central: fix buildbot waterfall URL

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -105,7 +105,7 @@ class PullRequestBuilder:
             for builder in cfg.buildbot.pr_builders:
                 status_evt = events.BuildStatus(
                     repo, head_sha, shortrev, builder, pr_id, False, True,
-                    cfg.buildbot.url + '/waterfall', 'Auto build in progress')
+                    cfg.buildbot.url + '/#/waterfall', 'Auto build in progress')
                 events.dispatcher.dispatch('prbuilder', status_evt)
 
             patch = requests.get('https://github.com/%s/pull/%d.patch' %


### PR DESCRIPTION
The "Details" links of pending checks currently 404.