### PR TITLE
central: don't send base_rev or head_rev to buildbot

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -22,8 +22,7 @@ def make_netstring(s):
     return str(len(s)).encode('ascii') + b':' + s + b','
 
 
-def make_build_request(repo, pr_id, job_id, baserev, headrev, who,
-                       comment):
+def make_build_request(repo, pr_id, job_id, who, comment):
     """Creates a build request binary blob in the format expected by the
     buildbot."""
 
@@ -31,15 +30,15 @@ def make_build_request(repo, pr_id, job_id, baserev, headrev, who,
         'branch': 'refs/pull/%d/head' % pr_id,
         'builderNames': cfg.buildbot.pr_builders,
         'jobid': job_id,
-        'baserev': baserev,
+        'baserev': '',
         'patch_level': 0,
         'patch_body': None,
         'who': who,
         'comment': comment,
         'properties': {
             'branchname': 'pr-%d' % pr_id,
-            'headrev': headrev,
-            'shortrev': headrev[:6],
+            'headrev': '',
+            'shortrev': '',
             'pr_id': pr_id,
             'repo': repo,
         },
@@ -109,8 +108,8 @@ class PullRequestBuilder:
                 events.dispatcher.dispatch('prbuilder', status_evt)
 
             req = make_build_request(
-                repo, pr_id, '%d-%s' % (pr_id, head_sha[:6]), base_sha,
-                head_sha, 'Central (on behalf of: %s)' % in_behalf_of,
+                repo, pr_id, '%d-%s' % (pr_id, head_sha[:6]),
+                'Central (on behalf of: %s)' % in_behalf_of,
                 'Auto build for PR #%d (%s).' % (pr_id, head_sha))
             send_build_request(req)
 


### PR DESCRIPTION
Buildbot defers to the explicit revisions when they're available, rather than fetching the PR ref from GitHub. This causes it to only build the base ref, rather than the actual PR.