### PR TITLE
buildbot: calculate shortrev from got_revision if unavailable

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -42,6 +42,16 @@ WEBAUTH_PASSWORD = open("webauth-password.txt").read().strip()
 
 OVHPROXY_URL = "https://ovhproxy.dolphin-emu.org/?url="
 
+def shortrev(props):
+    """Property renderer that uses the passed in shortrev if available (usually
+    something like 5.0-XXXX) and falls back to calculating it from got_revision
+    if not."""
+
+    value = props.getProperty("shortrev", "")
+    if not value:
+        value = props.getProperty("got_revision")[:6]
+    return value
+
 class GitNoBranch(GitHub):
     """Monkey patch for stupid patch behavior."""
 
@@ -125,7 +135,7 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
 
-    branch = WithProperties("%s", "branchname")
+    branch = WithProperties("%(branchname)s")
     env = {"DOLPHIN_BRANCH": branch, "DOLPHIN_DISTRIBUTOR": "dolphin-emu.org"}
     f.addStep(Compile(command=["msbuild.exe", "/v:m", "/p:Platform=%s" % msarch,
                                "/p:Configuration=%s" % build_type,
@@ -147,7 +157,7 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
 
     dolphin_name = "DolphinD" if debug else "Dolphin"
     if not pr:
-        build_descr = WithProperties("%s-%s", "branchname", "shortrev")
+        build_descr = WithProperties("%(branchname)s-%(shortrev)s", shortrev=shortrev)
         pdb_file = "Build\\%s\\%s\\Dolphin\\bin\\%s.pdb" % (msarch, "Debug" if debug else "Release", dolphin_name)
         f.addStep(ShellCommand(command=["C:\\buildbot\\storesymbols.bat", pdb_file,
                                         "Dolphin %s" % arch, build_descr],
@@ -166,7 +176,7 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
                            description="copying output",
                            descriptionDone="output copy"))
 
-    out_filename = WithProperties("Dolphin-%%s-%%s-%s.7z" % arch, "branchname", "shortrev")
+    out_filename = WithProperties("Dolphin-%%(branchname)s-%%(shortrev)s-%s.7z" % arch, shortrev=shortrev)
     f.addStep(ShellCommand(command=["7z", "a", "-r", out_filename,
                                     "Dolphin-%s" % arch],
                            logEnviron=False,
@@ -179,14 +189,14 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
         fn_arch = arch
 
     if "normal" in mode:
-        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
-        url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
+        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%%(branchname)s-%%(shortrev)s-%s.7z" % fn_arch, shortrev=shortrev)
+        url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%%(branchname)s-%%(shortrev)s-%s.7z" % fn_arch, shortrev=shortrev)
     elif wip:
-        master_filename = WithProperties("/srv/http/dl/wips/%%s-dolphin-%%s-%%s-%s.7z" % fn_arch, "author", "branchname", "shortrev")
-        url = WithProperties("http://dl.dolphin-emu.org/wips/%%s-dolphin-%%s-%%s-%s.7z" % fn_arch, "author", "branchname", "shortrev")
+        master_filename = WithProperties("/srv/http/dl/wips/%%(author)s-dolphin-%%(branchname)s-%%(shortrev)s-%s.7z" % fn_arch, shortrev=shortrev)
+        url = WithProperties("http://dl.dolphin-emu.org/wips/%%(author)s-dolphin-%%(branchname)s-%%(shortrev)s-%s.7z" % fn_arch, shortrev=shortrev)
     elif pr:
-        master_filename = WithProperties("/srv/http/dl/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
-        url = WithProperties("http://dl.dolphin-emu.org/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
+        master_filename = WithProperties("/srv/http/dl/prs/%%(branchname)s-dolphin-latest-%s.7z" % fn_arch)
+        url = WithProperties("http://dl.dolphin-emu.org/prs/%%(branchname)s-dolphin-latest-%s.7z" % fn_arch)
     else:
         master_filename = url = ""
 
@@ -209,11 +219,11 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
     if "normal" in mode and "debug" not in mode:
         f.addStep(MasterShellCommand(command="/home/buildbot/bin/send_build.py",
                                      env={
-                                         "BRANCH": WithProperties("%s", "branchname"),
-                                         "SHORTREV": WithProperties("%s", "shortrev"),
-                                         "HASH": WithProperties("%s", "revision"),
-                                         "AUTHOR": WithProperties("%s", "author"),
-                                         "DESCRIPTION": WithProperties("%s", "description"),
+                                         "BRANCH": WithProperties("%(branchname)s"),
+                                         "SHORTREV": WithProperties("%(shortrev)s", shortrev=shortrev),
+                                         "HASH": WithProperties("%(got_revision)s"),
+                                         "AUTHOR": WithProperties("%(author)s"),
+                                         "DESCRIPTION": WithProperties("%(description)s"),
                                          "TARGET_SYSTEM": "Windows x86" if arch == "x86" else "Windows x64",
                                          "USER_OS_MATCHER": "win",
                                          "BUILD_URL": url,
@@ -247,7 +257,7 @@ def make_fifoci_win(type, mode="normal"):
                            descriptionDone="FifoCI update"))
     f.addStep(RemoveDirectory("build/tmp", haltOnFailure=False, flunkOnFailure=False))
     f.addStep(MakeDirectory("build/tmp"))
-    f.addStep(ShellCommand(command=WithProperties("powershell C:/utils/bin/wgetwrapper.ps1 %s%%s build.7z" % (OVHPROXY_URL if ovhproxy else ""), "build_url"),
+    f.addStep(ShellCommand(command=WithProperties("powershell C:/utils/bin/wgetwrapper.ps1 %s%%(build_url)s build.7z" % (OVHPROXY_URL if ovhproxy else "")),
                            description="downloading build",
                            descriptionDone="download",
                            workdir="build/tmp",
@@ -282,7 +292,7 @@ def make_fifoci_win(type, mode="normal"):
             "--rev_submitted", "false",
         ]
     command = "C:/Python34/python.exe C:/fifoci/runner/runner.py " + " ".join(args)
-    f.addStep(ShellCommand(command=WithProperties(command),
+    f.addStep(ShellCommand(command=WithProperties(command, shortrev=shortrev),
                            workdir="build/tmp",
                            description="gfx testing",
                            descriptionDone="gfx test",
@@ -338,7 +348,7 @@ def make_dolphin_osx_build(mode="normal"):
     f.addStep(ShellCommand(command=["hdiutil", "create", "dolphin.dmg",
                                     "-format", "UDBZ",
                                     "-srcfolder", "Binaries/Dolphin.app", "-ov",
-                                    "-volname", WithProperties("Dolphin %s-%s", "branchname", "shortrev")],
+                                    "-volname", WithProperties("Dolphin %(branchname)s-%(shortrev)s", shortrev=shortrev)],
                            workdir="build/build",
                            logEnviron=False,
                            description="packaging",
@@ -351,14 +361,14 @@ def make_dolphin_osx_build(mode="normal"):
                            haltOnFailure=True))
 
     if mode == "normal":
-        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.dmg", "branchname", "shortrev")
-        url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%s-%s.dmg", "branchname", "shortrev")
+        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%(branchname)s-%(shortrev)s.dmg", shortrev=shortrev)
+        url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%(branchname)s-%(shortrev)s.dmg", shortrev=shortrev)
     elif mode == "wip":
-        master_filename = WithProperties("/srv/http/dl/wips/%s-dolphin-%s-%s.dmg", "author", "branchname", "shortrev")
-        url = WithProperties("http://dl.dolphin-emu.org/wips/%s-dolphin-%s-%s.dmg", "author", "branchname", "shortrev")
+        master_filename = WithProperties("/srv/http/dl/wips/%(author)s-dolphin-%(branchname)s-%(shortrev)s.dmg", shortrev=shortrev)
+        url = WithProperties("http://dl.dolphin-emu.org/wips/%(author)s-dolphin-%(branchname)s-%(shortrev)s.dmg", shortrev=shortrev)
     elif mode == "pr":
-        master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest.dmg", "branchname")
-        url = WithProperties("http://dl.dolphin-emu.org/prs/%s-dolphin-latest.dmg", "branchname")
+        master_filename = WithProperties("/srv/http/dl/prs/%(branchname)s-dolphin-latest.dmg")
+        url = WithProperties("http://dl.dolphin-emu.org/prs/%(branchname)s-dolphin-latest.dmg")
     else:
         master_filename = url = ""
 
@@ -369,11 +379,11 @@ def make_dolphin_osx_build(mode="normal"):
     if mode == "normal":
         f.addStep(MasterShellCommand(command="/home/buildbot/bin/send_build.py",
                                      env={
-                                         "BRANCH": WithProperties("%s", "branchname"),
-                                         "SHORTREV": WithProperties("%s", "shortrev"),
-                                         "HASH": WithProperties("%s", "revision"),
-                                         "AUTHOR": WithProperties("%s", "author"),
-                                         "DESCRIPTION": WithProperties("%s", "description"),
+                                         "BRANCH": WithProperties("%(branchname)s"),
+                                         "SHORTREV": WithProperties("%(shortrev)s", "shortrev"),
+                                         "HASH": WithProperties("%(got_revision)s"),
+                                         "AUTHOR": WithProperties("%(author)s"),
+                                         "DESCRIPTION": WithProperties("%(description)s"),
                                          "TARGET_SYSTEM": "macOS",
                                          "USER_OS_MATCHER": "osx",
                                          "BUILD_URL": url,
@@ -450,8 +460,8 @@ def make_android_package(mode="normal"):
                                haltOnFailure=True))
 
         source_filename = "Source/Android/app/build/outputs/apk/app-release.apk"
-        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
-        url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
+        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%(branchname)s-%(shortrev)s.apk", shortrev=shortrev)
+        url = WithProperties("http://dl.dolphin-emu.org/builds/dolphin-%(branchname)s-%(shortrev)s.apk", shortrev=shortrev)
 
     else:
         f.addStep(ShellCommand(command="./gradlew assembleDebug",
@@ -461,8 +471,8 @@ def make_android_package(mode="normal"):
                                haltOnFailure=True))
 
         source_filename = "Source/Android/app/build/outputs/apk/app-debug.apk"
-        master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest.apk", "branchname")
-        url = WithProperties("http://dl.dolphin-emu.org/prs/%s-dolphin-latest.apk", "branchname")
+        master_filename = WithProperties("/srv/http/dl/prs/%(branchname)s-dolphin-latest.apk")
+        url = WithProperties("http://dl.dolphin-emu.org/prs/%(branchname)s-dolphin-latest.apk")
 
     f.addStep(FileUpload(workersrc=source_filename,
                              masterdest=master_filename,
@@ -471,11 +481,11 @@ def make_android_package(mode="normal"):
     if mode == "normal":
         f.addStep(MasterShellCommand(command="/home/buildbot/bin/send_build.py",
                                      env={
-                                         "BRANCH": WithProperties("%s", "branchname"),
-                                         "SHORTREV": WithProperties("%s", "shortrev"),
-                                         "HASH": WithProperties("%s", "revision"),
-                                         "AUTHOR": WithProperties("%s", "author"),
-                                         "DESCRIPTION": WithProperties("%s", "description"),
+                                         "BRANCH": WithProperties("%(branchname)s"),
+                                         "SHORTREV": WithProperties("%(shortrev)s", shortrev),
+                                         "HASH": WithProperties("%(got_revision)s"),
+                                         "AUTHOR": WithProperties("%(author)s"),
+                                         "DESCRIPTION": WithProperties("%(description)s"),
                                          "TARGET_SYSTEM": "Android",
                                          "USER_OS_MATCHER": "android",
                                          "BUILD_URL": url,
@@ -588,7 +598,7 @@ def make_fifoci_linux(type, mode="normal"):
             "--rev_submitted", "false",
         ]
     command = "~/python ~/fifoci/runner/runner.py " + " ".join(args)
-    f.addStep(ShellCommand(command=WithProperties(command),
+    f.addStep(ShellCommand(command=WithProperties(command, shortrev=shortrev),
                            workdir="build/build",
                            description="gfx testing",
                            descriptionDone="gfx test",


### PR DESCRIPTION
Since abfec0d and 84ebb84, PR builds no longer have the `shortrev` property. This changes buildbot to calculate it automatically from `got_revision` if it's unavailable.