### PR TITLE
buildbot: Run lint against commits that are not on master

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -640,7 +640,7 @@ def make_lint():
     f = BuildFactory()
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
-    f.addStep(ShellCommand(command='Tools/lint.sh',
+    f.addStep(ShellCommand(command=['Tools/lint.sh', 'master...'],
                            logEnviron=False,
                            description="lint",
                            descriptionDone="lint",


### PR DESCRIPTION
Instead of applying PRs as patches and leaving them as staged changes, the lint builder now checks out the PR branch, so we must run lint on all files that were touched by commits in the PR branch (not on master), not staged files.