### PR TITLE
buildbot: Prioritise lint builds

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -94,7 +94,7 @@ def prioritize_builders(buildmaster, builders):
             return 2
         elif "fifoci-" in name:
             return 1
-        elif "release-" in name:
+        elif "release-" in name or "lint" in name:
             return 0
         else:
             return 6


### PR DESCRIPTION
They're usually really quick and people should be informed about what they need to change asap instead of minutes later.