### PR TITLE
buildbot: fetch base rev before linting against it

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -640,6 +640,10 @@ def make_lint():
     f = BuildFactory()
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
+    # Make sure the baserev exists locally. GitHub's "baserev" property is
+    # the current base branch head, which isn't guaranteed to exist in the PR
+    # branch (e.g. if it hasn't been rebased).
+    f.addStep(ShellCommand(command=['git', 'fetch', 'origin', WithProperties("%s", "baserev")]))
     f.addStep(ShellCommand(command=['Tools/lint.sh', WithProperties("%s...", "baserev")],
                            logEnviron=False,
                            description="lint",


### PR DESCRIPTION
Makes sure the baserev exists locally, in an attempt to fix the `invalid symmetric difference expression` errors. GitHub's "baserev" property is the current base branch head, which isn't guaranteed to exist in the PR branch (e.g. if it hasn't been rebased)!