### PR TITLE
buildbot: lint against base ref instead of sha

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -640,11 +640,8 @@ def make_lint():
     f = BuildFactory()
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
-    # Make sure the baserev exists locally. GitHub's "baserev" property is
-    # the current base branch head, which isn't guaranteed to exist in the PR
-    # branch (e.g. if it hasn't been rebased).
-    f.addStep(ShellCommand(command=['git', 'fetch', 'origin', WithProperties("%s", "baserev")]))
-    f.addStep(ShellCommand(command=['Tools/lint.sh', WithProperties("%s...", "baserev")],
+    f.addStep(ShellCommand(command=['git', 'fetch', 'origin', WithProperties("%s", "baseref")]))
+    f.addStep(ShellCommand(command=['Tools/lint.sh', WithProperties("%s...", "baseref")],
                            logEnviron=False,
                            description="lint",
                            descriptionDone="lint",

--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -22,7 +22,7 @@ def make_netstring(s):
     return str(len(s)).encode('ascii') + b':' + s + b','
 
 
-def make_build_request(repo, pr_id, job_id, baserev, headrev, who, comment):
+def make_build_request(repo, pr_id, job_id, base_ref, headrev, who, comment):
     """Creates a build request binary blob in the format expected by the
     buildbot."""
 
@@ -37,7 +37,7 @@ def make_build_request(repo, pr_id, job_id, baserev, headrev, who, comment):
         'comment': comment,
         'properties': {
             'branchname': 'pr-%d' % pr_id,
-            'baserev': baserev,
+            'baseref': base_ref,
             'headrev': headrev,
             'shortrev': headrev[:6],
             'pr_id': pr_id,
@@ -76,7 +76,7 @@ class PullRequestBuilder:
             logging.info('PR %s mergeable: %s (%s)', pr_id, pr['mergeable'],
                          pr['mergeable_state'])
 
-            base_sha = pr['base']['sha']
+            base_ref = pr['base']['ref']
             head_sha = pr['head']['sha']
 
             shortrev = head_sha[:6]
@@ -103,7 +103,7 @@ class PullRequestBuilder:
             events.dispatcher.dispatch('prbuilder', status_evt)
 
             req = make_build_request(
-                repo, pr_id, '%d-%s' % (pr_id, head_sha[:6]), base_sha, head_sha,
+                repo, pr_id, '%d-%s' % (pr_id, head_sha[:6]), base_ref, head_sha,
                 'Central (on behalf of: %s)' % in_behalf_of,
                 'Auto build for PR #%d (%s).' % (pr_id, head_sha))
             send_build_request(req)


### PR DESCRIPTION
The current logic tries to lint against the merge-base of the PR and GitHub's reported base sha. Unfortunately, the base sha isn't guaranteed to exist yet on the buildbot, as it's only sometimes in the ancestry graph of the PR.

The previous fix attempted to fetch the relevant sha directly from GitHub before calculating the merge-base. This also failed, because git isn't required to support directly fetching shas, only refnames. (Confusingly, if you try this out locally, git will claim it successfully fetched the sha if it already exists, rather than telling you that that's an invalid operation.)

This PR gives up on passing the base sha and passes the base ref name. For example, where before we would try to lint against "...918b037", now we would simply lint against "...master".