### PR TITLE
Redirect lookup for the README.md file

### DIFF
--- a/redirector/main.go
+++ b/redirector/main.go
@@ -81,7 +81,7 @@ func MakeStaticRedirector(pattern string, url string) Redirector {
 var readmeContents = GetReadme()
 
 func GetReadme() string {
-	s, err := ioutil.ReadFile("README")
+	s, err := ioutil.ReadFile("README.md")
 	if err != nil {
 		return "No README found. Cannot provide you with documentation ☹"
 	}


### PR DESCRIPTION
An extension to the README was recently added but the file is also read from here and needs to be updated too.

Otherwise going to dolp.in will result in the message "No README found. Cannot provide you with documentation ☹".