### PR TITLE
lint: Fetch all revisions.

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -643,7 +643,7 @@ def make_lint():
     # Make sure the baserev exists locally. GitHub's "baserev" property is
     # the current base branch head, which isn't guaranteed to exist in the PR
     # branch (e.g. if it hasn't been rebased).
-    f.addStep(ShellCommand(command=['git', 'fetch', 'origin', WithProperties("%s", "baserev")]))
+    f.addStep(ShellCommand(command=['git', 'fetch', 'origin']))
     f.addStep(ShellCommand(command=['Tools/lint.sh', WithProperties("%s...", "baserev")],
                            logEnviron=False,
                            description="lint",


### PR DESCRIPTION
Fetching a single revision is an optional host feature, and it is disabled on github. This fails right now if the PR isn't based on master directly.