### PR TITLE
Buildbot/OSX: Sign Qt app bundle

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -337,6 +337,12 @@ def make_dolphin_osx_build(mode="normal"):
                            descriptionDone="sign",
                            haltOnFailure=True))
 
+    f.addStep(ShellCommand(command="/build/codesign.sh --deep Binaries/dolphin-emu-qt2.app",
+                           workdir="build/build",
+                           description="signing qt",
+                           descriptionDone="sign qt",
+                           haltOnFailure=True))
+
     # hdiutil is broken and doesn't support multiple folders (despite claiming it does on its man page)
     # Creating a temporary folder to work around this
     f.addStep(ShellCommand(command="rm -rf staging && mkdir staging && cp -a Binaries/Dolphin.app Binaries/dolphin-emu-qt2.app staging",


### PR DESCRIPTION
The Qt version of Dolphin has to be signed too.