### PR TITLE
buildbot: enable console view

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -937,6 +937,7 @@ BuildmasterConfig = {
         "auth": util.UserPasswordAuth({"dolphin": WEBAUTH_PASSWORD}),
         "plugins": {
             "waterfall_view": {"num_builds": 50},
+            "console_view": {},
         },
     },
 


### PR DESCRIPTION
I find console view very useful (better than waterfall these days); any chance of adding it here?

Here's what it looks like for mGBA: https://buildbot.mgba.io/#/console