### PR TITLE
buildbot: replace ENABLE_QT2=OFF with ENABLE_QT=OFF

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -552,7 +552,7 @@ def make_fifoci_linux(type, mode="normal"):
                            description="mkbuilddir",
                            descriptionDone="mkbuilddir"))
 
-    f.addStep(ShellCommand(command="cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/prefix -DENABLE_WX=OFF -DENABLE_QT2=OFF -DENABLE_EVDEV=OFF -GNinja ..",
+    f.addStep(ShellCommand(command="cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/prefix -DENABLE_QT=OFF -DENABLE_EVDEV=OFF -GNinja ..",
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",
@@ -622,7 +622,7 @@ def make_arm():
                            description="mkbuilddir",
                            descriptionDone="mkbuilddir"))
 
-    f.addStep(ShellCommand(command="cmake -DENABLE_WX=OFF -DENABLE_QT2=OFF -GNinja ..",
+    f.addStep(ShellCommand(command="cmake -DENABLE_QT=OFF -GNinja ..",
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",


### PR DESCRIPTION
Also removes ENABLE_WX=OFF, as it is no longer valid. Should fix the fifoci runners.

(fifoci has been broken for a while)