### PR TITLE
buildbot/master.cfg: Disable frame dump encoding on macOS

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -318,7 +318,7 @@ def make_dolphin_osx_build(mode="normal"):
                            description="mkbuilddir",
                            descriptionDone="mkbuilddir"))
 
-    f.addStep(ShellCommand(command=["cmake", "-GNinja", "-DDISTRIBUTOR=dolphin-emu.org", ".."],
+    f.addStep(ShellCommand(command=["cmake", "-GNinja", "-DDISTRIBUTOR=dolphin-emu.org", "-DENCODE_FRAMEDUMPS=OFF", ".."],
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",


### PR DESCRIPTION
Causes the bundle to explode in size.