### PR TITLE
central: Add missing properties to GHPullRequest event

### DIFF
--- a/central/events.py
+++ b/central/events.py
@@ -109,7 +109,8 @@ def GHPush(repo: str, pusher: str, before_sha: str, after_sha: str, commits:
 @event('gh_pull_request')
 def GHPullRequest(repo: str, author: str, action: str, id: int, title: str,
                   base_ref_name: str, head_ref_name: str, base_sha: str,
-                  head_sha: str, url: str, safe_author: bool):
+                  head_sha: str, url: str, safe_author: bool, merged: bool,
+                  requested_reviewers: list):
     return {'repo': repo,
             'author': author,
             'action': action,
@@ -120,7 +121,9 @@ def GHPullRequest(repo: str, author: str, action: str, id: int, title: str,
             'head_ref_name': head_ref_name,
             'safe_author': safe_author,
             'base_sha': base_sha,
-            'head_sha': head_sha}
+            'head_sha': head_sha,
+            'merged': merged,
+            'requested_reviewers': requested_reviewers}
 
 
 @event('gh_pull_request_review')

--- a/central/github.py
+++ b/central/github.py
@@ -250,7 +250,8 @@ class GHHookEventParser(events.EventTarget):
         return events.GHPullRequest(
             repo, author, raw.action, raw.pull_request.number,
             raw.pull_request.title, base_ref_name, head_ref_name, base_sha,
-            head_sha, raw.pull_request.html_url, is_safe_author(author))
+            head_sha, raw.pull_request.html_url, is_safe_author(author),
+            raw.pull_request.merged, raw.pull_request.requested_reviewers)
 
     def convert_pull_request_review(self, raw):
         repo = raw.repository.owner.login + '/' + raw.repository.name


### PR DESCRIPTION
Follow-up to #101. Sorry, I forgot that evt isn't the GitHub webhook data but a GHPullRequest event, so the new properties also need to be added there.