### PR TITLE
central: Send PR status events before triggering builds

### DIFF
--- a/central/buildbot.py
+++ b/central/buildbot.py
@@ -102,6 +102,12 @@ class PullRequestBuilder:
                 'Very basic checks passed, handed off to Buildbot.')
             events.dispatcher.dispatch('prbuilder', status_evt)
 
+            for builder in cfg.buildbot.pr_builders:
+                status_evt = events.BuildStatus(repo, head_sha, shortrev, builder,
+                                                pr_id, False, True, cfg.buildbot.url,
+                                                'Auto build pending')
+                events.dispatcher.dispatch('prbuilder', status_evt)
+
             req = make_build_request(
                 repo, pr_id, '%d-%s' % (pr_id, head_sha[:6]), base_sha, head_sha,
                 'Central (on behalf of: %s)' % in_behalf_of,


### PR DESCRIPTION
This was removed when I added support for Buildbot pending build events
as I had assumed that Buildbot would send build events fast enough.

However one problem that is made obvious by the occasional build upload
issues is that Buildbot only sends events when a build has started
and not when a build is queued, which means that a builder getting
stuck can cause PRs to get the green "all checks passed" status
even when builds haven't actually started on some builders.