### PR TITLE
buildbot: Run send_build.py with Python 3

### DIFF
--- a/buildbot/send_build.py
+++ b/buildbot/send_build.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 
 import hashlib
 import hmac


### PR DESCRIPTION
Looks like the script was still being run with Python 2, which causes
it to break if any of the environment variables contains non-ASCII
characters (like the é in my name...)