### PR TITLE
Create redirect to FifoCI by Git hash

### DIFF
--- a/redirector/README.md
+++ b/redirector/README.md
@@ -17,6 +17,8 @@ Currently supports:
   * http://dolp.in/i (list of bugs)
   * http://dolp.in/i$ISSUE_NUMBER (issue page)
   * http://dolp.in/i$ISSUE_NUMBER/$COMMENT_NUMBER (issue comment)
+* fifoci.dolphin-emu.org:
+  * http://dolp.in/fi$GIT_HASH (FifoCI Results)
 * dolphin-emu.org:
   * http://dolp.in/dl (download page)
   * http://dolp.in/faq (FAQ page)

--- a/redirector/main.go
+++ b/redirector/main.go
@@ -24,6 +24,7 @@ var redirectors = []Redirector{
 	MakeStaticRedirector(`/bbs(/.*)?`, `https://forums.dolphin-emu.org`),
 	MakeStaticRedirector(`/pr(/.*)?`, `https://github.com/dolphin-emu/dolphin/pulls`),
 	MakeStaticRedirector(`/i(/.*)?`, `https://bugs.dolphin-emu.org/projects/emulator/issues`),
+	MakeStaticRedirector(`/fi(/.*)?`, `https://fifoci.dolphin-emu.org/version`),
 
 	// Versions
 	MakeStaticRedirector(`/v(\d.*)/?`, `https://dolphin-emu.org/download/dev/master/`),


### PR DESCRIPTION
I thought it would be nice to include a redirect to FifoCI in order to show the PRs results.