### PR TITLE
buildbot: Use newer compilers (Clang 8 for pr-deb, GCC 10 for pr-ubu)

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -478,7 +478,7 @@ def make_dolphin_osx_build(mode="normal"):
 
     return f
 
-def make_dolphin_linux_build(mode="normal"):
+def make_dolphin_linux_build(mode="normal", env={}):
     f = BuildFactory()
 
     mode = mode.split(",")
@@ -507,7 +507,8 @@ def make_dolphin_linux_build(mode="normal"):
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",
-                           haltOnFailure=True))
+                           haltOnFailure=True,
+                           env=env))
 
     f.addStep(Compile(command=["ninja"],
                       workdir="build/build",
@@ -736,6 +737,16 @@ freebsd_release = AnyBranchScheduler(name="freebsd-release", builderNames=["rele
 
 lint_release = AnyBranchScheduler(name="lint-release", builderNames=["lint"])
 
+BUILDER_ENV_DEBIAN = {
+    "CC": "clang-8",
+    "CXX": "clang++-8",
+}
+
+BUILDER_ENV_UBUNTU = {
+    "CC": "gcc-10",
+    "CXX": "g++-10",
+}
+
 BuildmasterConfig = {
     "title": "Dolphin Emulator",
     "titleURL": "https://github.com/dolphin-emu/dolphin.git",
@@ -821,9 +832,9 @@ BuildmasterConfig = {
         BuilderConfig(name="release-osx-x64", workernames=["osx"],
                       factory=make_dolphin_osx_build()),
         BuilderConfig(name="release-deb-x64", workernames=["debian"],
-                      factory=make_dolphin_linux_build()),
+                      factory=make_dolphin_linux_build(env=BUILDER_ENV_DEBIAN)),
         BuilderConfig(name="release-ubu-x64", workernames=["ubuntu"],
-                      factory=make_dolphin_linux_build("fifoci_golden")),
+                      factory=make_dolphin_linux_build("fifoci_golden", env=BUILDER_ENV_UBUNTU)),
         BuilderConfig(name="release-android", workernames=["ubuntu"],
                       factory=make_android_package()),
         BuilderConfig(name="release-freebsd-x64", workernames=["freebsd"],
@@ -836,11 +847,11 @@ BuildmasterConfig = {
         BuilderConfig(name="pr-osx-x64", workernames=["osx"],
                       factory=make_dolphin_osx_build("pr")),
         BuilderConfig(name="pr-deb-x64", workernames=["debian"],
-                      factory=make_dolphin_linux_build("pr")),
+                      factory=make_dolphin_linux_build("pr", env=BUILDER_ENV_DEBIAN)),
         BuilderConfig(name="pr-deb-dbg-x64", workernames=["debian"],
-                      factory=make_dolphin_linux_build("pr,debug")),
+                      factory=make_dolphin_linux_build("pr,debug", env=BUILDER_ENV_DEBIAN)),
         BuilderConfig(name="pr-ubu-x64", workernames=["ubuntu"],
-                      factory=make_dolphin_linux_build("pr,fifoci_golden")),
+                      factory=make_dolphin_linux_build("pr,fifoci_golden", env=BUILDER_ENV_UBUNTU)),
         BuilderConfig(name="pr-android", workernames=["ubuntu"],
                       factory=make_android_package("pr")),
         BuilderConfig(name="pr-freebsd-x64", workernames=["freebsd"],
@@ -867,7 +878,7 @@ BuildmasterConfig = {
                       factory=make_lint()),
 
         BuilderConfig(name="nightly-generic", workernames=["ubuntu"],
-                      factory=make_dolphin_linux_build("nightly,generic")),
+                      factory=make_dolphin_linux_build("nightly,generic", env=BUILDER_ENV_UBUNTU)),
     ],
 
     "www": {


### PR DESCRIPTION
Several compiler bugs in GCC <10 are hindering the fmt migration.
We've already had to add workarounds for those versions in the format
macros to fix compilation issues (dolphin-emu/dolphin#9260).

Adding DEBUG_ASSERT_MSG_FMT seems to be impossible as those older
versions misdetect the return type of lamba functions in fmt code...
Unlike PR 9260, it doesn't look like there are workarounds; applying
the fix from https://github.com/fmtlib/fmt/pull/1580 doesn't help.

Also, older versions of GCC (8, 9) are already broken in several ways:
adding constexpr to some Matrix functions causes GCC 8 to generate
bugged code that causes the Wii IR pointer to disappear
(see https://dolp.in/i12324).

As GCC 8 already silently produces unusable builds, I think we should
bump our GCC version requirement and require compiling with newer
versions of GCC or with Clang.

---

For CI:

* Clang 8 is already installed on the Debian buildbot.

* I'm not sure what version of Ubuntu is used in the Ubuntu container;
  GCC 10 may need to be installed from the Ubuntu toolchain PPA.