### PR TITLE
Apple M1: Add M1 buildbot-worker

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -347,6 +347,135 @@ def make_fifoci_win(type, mode="normal"):
 
     return f
 
+def make_dolphin_osx_universal_build(mode="normal"):
+    f = BuildFactory()
+
+    f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
+                          progress=True, mode="incremental"))
+
+    f.addStep(ShellCommand(command=["mkdir", "-p", "build"],
+                           logEnviron=False,
+                           description="mkbuilddir",
+                           descriptionDone="mkbuilddir",
+                           hideStepIf=StepWasSuccessful))
+
+    f.addStep(ShellCommand(command=["../BuildMacOSUniversalBinary.py", "-G", "Ninja"],
+                           workdir="build/build",
+                           description="configuring",
+                           descriptionDone="configure",
+                           haltOnFailure=True))
+
+    # code signing not enabled curently
+    # f.addStep(ShellCommand(command="/build/codesign.sh --deep universal/Dolphin.app",
+    #                        workdir="build/build",
+    #                        description="signing",
+    #                        descriptionDone="sign",
+    #                        haltOnFailure=True))
+
+    f.addStep(ShellCommand(command="rm -rf dmg.dir && mkdir dmg.dir",
+                           workdir="build/build",
+                           description="creating tmp dir",
+                           descriptionDone="create tmp dir",
+                           haltOnFailure=True,
+                           hideStepIf=StepWasSuccessful))
+
+    f.addStep(ShellCommand(command="cp -R universal/Dolphin.app dmg.dir",
+                           workdir="build/build",
+                           description="creating tmp dir",
+                           descriptionDone="create tmp dir",
+                           haltOnFailure=True,
+                           hideStepIf=StepWasSuccessful))
+
+    f.addStep(ShellCommand(command="cp -R universal/Dolphin\ Updater.app dmg.dir",
+                           workdir="build/build",
+                           description="creating tmp dir",
+                           descriptionDone="create tmp dir",
+                           haltOnFailure=True #,hideStepIf=StepWasSuccessful
+                           ))
+
+    # code signing not enabled currently
+    # f.addStep(ShellCommand(command=r"/build/codesign.sh --deep universal/Dolphin\ Updater.app; cp -R universal/Dolphin\ Updater.app dmg.dir",
+    #                        workdir="build/build",
+    #                        description="signing updater",
+    #                        descriptionDone="sign updater",
+    #                        haltOnFailure=True))
+
+    f.addStep(ShellCommand(command=["hdiutil", "create", "dolphin.dmg",
+                                    "-format", "UDBZ",
+                                    "-fs", "HFS+", # Needed for 7-Zip support
+                                    "-srcfolder", "dmg.dir", "-ov",
+                                    "-volname", "Dolphin"],
+                                    #"-volname", "dolphin.dmg"],
+                           workdir="build/build",
+                           logEnviron=False,
+                           description="packaging",
+                           descriptionDone="package"))
+    # code signing not enabled currently
+    # f.addStep(ShellCommand(command="/build/codesign.sh --deep dolphin.dmg",
+    #                        workdir="build/build",
+    #                        description="signing dmg",
+    #                        descriptionDone="sign dmg",
+    #                        haltOnFailure=True))
+
+    if mode == "normal":
+        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
+        url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
+    elif mode == "wip":
+        master_filename = WithProperties("/srv/http/dl/wips/%s-dolphin-%s-%s-universal.dmg", "author", "branchname", "shortrev")
+        url = WithProperties("https://dl.dolphin-emu.org/wips/%s-dolphin-%s-%s-universal.dmg", "author", "branchname", "shortrev")
+    elif mode == "pr":
+        master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest-universal.dmg", "branchname")
+        url = WithProperties("https://dl.dolphin-emu.org/prs/%s-dolphin-latest-universal.dmg", "branchname")
+    else:
+        master_filename = url = ""
+
+    master_filename, url = map(get_sharded_dl_path, (master_filename, url))
+
+    if master_filename and url:
+         f.addSteps(ReliableFileUpload(workersrc="build/dolphin.dmg",
+                                      masterdest=master_filename,
+                                      url=url, keepstamp=True, mode=0o644))
+
+    if mode == "normal":
+
+         f.addStep(MasterShellCommand(command="/home/buildbot/bin/send_build.py",
+                                        env={
+                                            "BRANCH": WithProperties("%s", "branchname"),
+                                            "SHORTREV": WithProperties("%s", "shortrev"),
+                                            "HASH": WithProperties("%s", "revision"),
+                                            "AUTHOR": WithProperties("%s", "author"),
+                                            "DESCRIPTION": WithProperties("%s", "description"),
+                                            "TARGET_SYSTEM": "macOS (ARM/Intel Universal)",
+                                            "USER_OS_MATCHER": "osx",
+                                            "BUILD_URL": url,
+                                        },
+                                        description="notifying website",
+                                        descriptionDone="website notice"))
+
+         tmp_filename = WithProperties("/tmp/%s.7z", "revision")
+
+         f.addStep(MasterShellCommand(command=["/home/buildbot/bin/repack_dmg.sh", master_filename, tmp_filename],
+                                      description="converting dmg",
+                                      descriptionDone="convert dmg",
+                                      hideStepIf=StepWasSuccessful))
+
+         f.addStep(MasterShellCommand(command=["/home/buildbot/venv/bin/python", "/home/buildbot/bin/make_manifest.py",
+                                             "--input", tmp_filename,
+                                             "--version_hash", WithProperties("%s", "revision"),
+                                             "--platform", "macos-universal",
+                                             "--output-manifest-store", "/data/nas/update/manifest",
+                                              "--output-content-store", "/data/nas/update/content",
+                                             "--signing-key", "/home/buildbot/update.signing.key"],
+                                      description="writing update manifest",
+                                      descriptionDone="update manifest write"))
+
+         f.addStep(MasterShellCommand(command=["rm", tmp_filename],
+                                      description="cleaning up",
+                                      descriptionDone="clean up",
+                                      hideStepIf=StepWasSuccessful))
+
+    return f
+
 def make_dolphin_osx_build(mode="normal"):
     f = BuildFactory()
 
@@ -447,7 +576,7 @@ def make_dolphin_osx_build(mode="normal"):
                                          "HASH": WithProperties("%s", "revision"),
                                          "AUTHOR": WithProperties("%s", "author"),
                                          "DESCRIPTION": WithProperties("%s", "description"),
-                                         "TARGET_SYSTEM": "macOS",
+                                         "TARGET_SYSTEM": "macOS (Intel)",
                                          "USER_OS_MATCHER": "osx",
                                          "BUILD_URL": url,
                                      },
@@ -728,6 +857,7 @@ win64_release = AnyBranchScheduler(name="win64-release", builderNames=["release-
 win64_debug = Dependent(name="win64-debug", upstream=win64_release, builderNames=["debug-win-x64"])
 
 osx_release = AnyBranchScheduler(name="osx-release", builderNames=["release-osx-x64"])
+osx_universal_release = AnyBranchScheduler(name="osx-universal-release", builderNames=["release-osx-universal"])
 deb64_release = AnyBranchScheduler(name="deb64-release", builderNames=["release-deb-x64"])
 ubu64_release = AnyBranchScheduler(name="ubu64-release", builderNames=["release-ubu-x64"])
 android_release = Dependent(name="android-release", upstream=ubu64_release, builderNames=["release-android"])
@@ -759,6 +889,7 @@ BuildmasterConfig = {
     "workers": [
         Worker("windows", BUILDSLAVES_PASSWORDS["windows"], max_builds=1),
         Worker("osx", BUILDSLAVES_PASSWORDS["osx"], max_builds=1),
+        Worker("osx-m1", BUILDSLAVES_PASSWORDS["osx-m1"], max_builds=1),
         Worker("debian", BUILDSLAVES_PASSWORDS["debian"], max_builds=1),
         Worker("ubuntu", BUILDSLAVES_PASSWORDS["ubuntu"], max_builds=1),
         Worker("freebsd", BUILDSLAVES_PASSWORDS["freebsd"], max_builds=1),
@@ -778,6 +909,7 @@ BuildmasterConfig = {
         win64_release,
         win64_debug,
         osx_release,
+        osx_universal_release,
         deb64_release,
         ubu64_release,
         android_release,
@@ -802,6 +934,7 @@ BuildmasterConfig = {
                          "pr-win-x64",
                          "pr-win-dbg-x64",
                          "pr-osx-x64",
+                         "pr-osx-universal",
                          "pr-deb-x64",
                          "pr-deb-dbg-x64",
                          "pr-ubu-x64",
@@ -820,6 +953,8 @@ BuildmasterConfig = {
                       factory=make_dolphin_win_build("Release", "x64", "normal,fifoci_golden")),
         BuilderConfig(name="release-osx-x64", workernames=["osx"],
                       factory=make_dolphin_osx_build()),
+        BuilderConfig(name="release-osx-universal", workernames=["osx-m1"],
+                      factory=make_dolphin_osx_universal_build()),
         BuilderConfig(name="release-deb-x64", workernames=["debian"],
                       factory=make_dolphin_linux_build()),
         BuilderConfig(name="release-ubu-x64", workernames=["ubuntu"],
@@ -835,6 +970,8 @@ BuildmasterConfig = {
                       factory=make_dolphin_win_build("Debug", "x64", "pr,debug")),
         BuilderConfig(name="pr-osx-x64", workernames=["osx"],
                       factory=make_dolphin_osx_build("pr")),
+        BuilderConfig(name="pr-osx-universal", workernames=["osx-m1"],
+                      factory=make_dolphin_osx_universal_build("pr")),
         BuilderConfig(name="pr-deb-x64", workernames=["debian"],
                       factory=make_dolphin_linux_build("pr")),
         BuilderConfig(name="pr-deb-dbg-x64", workernames=["debian"],


### PR DESCRIPTION
This is the corresponding change to the buildbots for:
https://github.com/dolphin-emu/dolphin/pull/9441

In theory this should be all the changes needed to support adding the M1 buildbot-worker when we have the machine, however I was only able to test part of it locally as I was unable to reproduce all of Dolphin's build infrastructure (like code signing, and the github integration).