### PR TITLE
Add uberogl fifoci builders

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -786,6 +786,7 @@ BuildmasterConfig = {
         Triggerable(name="fifoci-lin", builderNames=[
                         "fifoci-ogl-lin-mesa",
                         "fifoci-ogl-lin-radeon",
+                        "fifoci-uberogl-lin-radeon",
                         "fifoci-sw-lin-mesa",
                     ]),
         Triggerable(name="fifoci-win", builderNames=[
@@ -793,6 +794,7 @@ BuildmasterConfig = {
         Triggerable(name="pr-fifoci-lin", builderNames=[
                         "pr-fifoci-ogl-lin-mesa",
                         "pr-fifoci-ogl-lin-radeon",
+                        "pr-fifoci-uberogl-lin-radeon",
                         "pr-fifoci-sw-lin-mesa",
                     ]),
         Triggerable(name="pr-fifoci-win", builderNames=[
@@ -853,6 +855,8 @@ BuildmasterConfig = {
                       factory=make_fifoci_linux("ogl-lin-mesa")),
         BuilderConfig(name="fifoci-ogl-lin-radeon", workernames=["arbert"],
                       factory=make_fifoci_linux("ogl-lin-radeon")),
+        BuilderConfig(name="fifoci-uberogl-lin-radeon", workernames=["arbert"],
+                      factory=make_fifoci_linux("uberogl-lin-radeon")),
         BuilderConfig(name="fifoci-sw-lin-mesa", workernames=["hive"],
                       factory=make_fifoci_linux("sw-lin-mesa")),
 
@@ -860,6 +864,8 @@ BuildmasterConfig = {
                       factory=make_fifoci_linux("ogl-lin-mesa", "pr")),
         BuilderConfig(name="pr-fifoci-ogl-lin-radeon", workernames=["arbert"],
                       factory=make_fifoci_linux("ogl-lin-radeon", "pr")),
+        BuilderConfig(name="pr-fifoci-uberogl-lin-radeon", workernames=["arbert"],
+                      factory=make_fifoci_linux("uberogl-lin-radeon", "pr")),
         BuilderConfig(name="pr-fifoci-sw-lin-mesa", workernames=["hive"],
                       factory=make_fifoci_linux("sw-lin-mesa", "pr")),
 

--- a/central/config.yml
+++ b/central/config.yml
@@ -39,21 +39,23 @@ github:
 buildbot:
     url: https://dolphin.ci/
     jobdir: /home/buildbot/pr-jobdir
+    # Builders for which a BuildStatus event is dispatched on completion
     pr_builders:
         - pr-android
         - pr-deb-x64
         - pr-deb-dbg-x64
+        - pr-freebsd-x64
         - pr-osx-x64
         - pr-ubu-x64
-        - pr-ubu-noguix64
         - pr-win-x64
         - pr-win-dbg-x64
-        - pr-win-x86
         - lint
+    # Builders for which a PullRequestFifoCIStatus event is dispatched on completion
     fifoci_builders:
         - pr-fifoci-ogl-lin-mesa
-        - pr-fifoci-ogl-lin-nv
         - pr-fifoci-sw-lin-mesa
+        - pr-fifoci-ogl-lin-radeon
+        - pr-fifoci-uberogl-lin-radeon
 
 fifoci:
     url: https://fifoci.ci/


### PR DESCRIPTION
This PR adds a fifoci builder that uses OpenGL with Ubershaders.  I put this on arbert, which currently runs fifoci-ogl-lin-radeon, to try and balance it with hive, which runs fifoci-ogl-lin-mesa and fifoci-sw-lin-mesa.  This is under the assumption that the software renderer takes about as long as ubershaders, but I don't know for sure if that's actually the case (and my machine is too weak to make good comparisons).

Requires dolphin-emu/fifoci#36.  I haven't tested this myself, as I don't have anything set up locally.

Note that I've also sync'd central's config.yml with what I think should be correct.  Delroth mentioned that it didn't match what was currently in use in production (which makes sense given the API keys are dummied out), and that's consistent with pr-fifoci-ogl-lin-nv being listed (which hasn't been present since 0b27e20335860e928410750f24347505a75b0e06).