### PR TITLE
Override CMake Deployment Target for macOS x64

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -488,7 +488,7 @@ def make_dolphin_osx_build(mode="normal"):
                            descriptionDone="mkbuilddir",
                            hideStepIf=StepWasSuccessful))
 
-    f.addStep(ShellCommand(command=["cmake", "-GNinja", "-DDISTRIBUTOR=dolphin-emu.org", "-DENCODE_FRAMEDUMPS=OFF", ".."],
+    f.addStep(ShellCommand(command=["cmake", "-GNinja", "-DDISTRIBUTOR=dolphin-emu.org", "-DENCODE_FRAMEDUMPS=OFF", "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12.0", ".."],
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",


### PR DESCRIPTION
Overrides the x64 macOS deployment target to 10.12 in the legacy Intel only
buildbot. The universal buildbot already targets 10.12 in the build script.
