### PR TITLE
M1: Add flag to run unit tests during universal builds

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -359,7 +359,7 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            descriptionDone="mkbuilddir",
                            hideStepIf=StepWasSuccessful))
 
-    f.addStep(ShellCommand(command=["../BuildMacOSUniversalBinary.py", "-G", "Ninja"],
+    f.addStep(ShellCommand(command=["../BuildMacOSUniversalBinary.py", "-G", "Ninja", "--run_unit_tests"],
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",


### PR DESCRIPTION
This is the sadm change corresponding to: https://github.com/dolphin-emu/dolphin/pull/9830

It just adds the command line flag to execute the unit tests to the build command. It should be merged after https://github.com/dolphin-emu/dolphin/pull/9830 as it will cause the universal build to fail without the corresponding updates to the build script. 