### PR TITLE
make_manifest: Allow content store directory to already exist when attempting to create it

### DIFF
--- a/buildbot/make_manifest.py
+++ b/buildbot/make_manifest.py
@@ -14,8 +14,7 @@ import sys
 
 def write_to_content_store(base, h, contents):
     directory = os.path.join(base, h[0:2], h[2:4])
-    if not os.path.isdir(directory):
-        os.makedirs(directory)
+    os.makedirs(directory, exist_ok=True)
     path = os.path.join(directory, h[4:])
     if os.path.exists(path):
         return


### PR DESCRIPTION
[Writing the update manifest for the macOS universal version of 5.0-14753 failed](https://dolphin.ci/#/builders/27/builds/235) because a directory on the content store was non-existent when line 17 was executed, but was apparently created by something else (another buildbot?) before line 18 was executed. 

`os.makedirs` throwing a `FileExistsError` shouldn't be a problem, so ignore it.
