### PR TITLE
buildbot: fix a race condition between macos and macos-universal builders

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -452,7 +452,7 @@ def make_dolphin_osx_universal_build(mode="normal"):
                                         description="notifying website",
                                         descriptionDone="website notice"))
 
-         tmp_filename = WithProperties("/tmp/%s.7z", "revision")
+         tmp_filename = WithProperties("/tmp/macos-universal-%s.7z", "revision")
 
          f.addStep(MasterShellCommand(command=["/home/buildbot/bin/repack_dmg.sh", master_filename, tmp_filename],
                                       description="converting dmg",
@@ -583,7 +583,7 @@ def make_dolphin_osx_build(mode="normal"):
                                      description="notifying website",
                                      descriptionDone="website notice"))
 
-        tmp_filename = WithProperties("/tmp/%s.7z", "revision")
+        tmp_filename = WithProperties("/tmp/macos-%s.7z", "revision")
 
         f.addStep(MasterShellCommand(command=["/home/buildbot/bin/repack_dmg.sh", master_filename, tmp_filename],
                                      description="converting dmg",


### PR DESCRIPTION
Make the macOS and universal macOS builders use different output file
names for the repacked DMG -- otherwise they can race with each other
and overwrite another builder's DMG. That would cause a manifest
to be generated for the wrong build...

This issue was hit with Dolphin 35bf5e38392670b3b86a4926437d01157363ba4a