### PR TITLE
buildbot: remove remnants of wip builders

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -151,7 +151,6 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
     mode = mode.split(",")
     normal = "normal" in mode
     debug = "debug" in mode
-    wip = "wip" in mode
     pr = "pr" in mode
     fifoci_golden = "fifoci_golden" in mode
 
@@ -211,9 +210,6 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
     if "normal" in mode:
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
         url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
-    elif wip:
-        master_filename = WithProperties("/srv/http/dl/wips/%%s-dolphin-%%s-%%s-%s.7z" % fn_arch, "author", "branchname", "shortrev")
-        url = WithProperties("https://dl.dolphin-emu.org/wips/%%s-dolphin-%%s-%%s-%s.7z" % fn_arch, "author", "branchname", "shortrev")
     elif pr:
         master_filename = WithProperties("/srv/http/dl/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
         url = WithProperties("https://dl.dolphin-emu.org/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
@@ -420,9 +416,6 @@ def make_dolphin_osx_universal_build(mode="normal"):
     if mode == "normal":
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
         url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
-    elif mode == "wip":
-        master_filename = WithProperties("/srv/http/dl/wips/%s-dolphin-%s-%s-universal.dmg", "author", "branchname", "shortrev")
-        url = WithProperties("https://dl.dolphin-emu.org/wips/%s-dolphin-%s-%s-universal.dmg", "author", "branchname", "shortrev")
     elif mode == "pr":
         master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest-universal.dmg", "branchname")
         url = WithProperties("https://dl.dolphin-emu.org/prs/%s-dolphin-latest-universal.dmg", "branchname")
@@ -551,9 +544,6 @@ def make_dolphin_osx_build(mode="normal"):
     if mode == "normal":
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.dmg", "branchname", "shortrev")
         url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s.dmg", "branchname", "shortrev")
-    elif mode == "wip":
-        master_filename = WithProperties("/srv/http/dl/wips/%s-dolphin-%s-%s.dmg", "author", "branchname", "shortrev")
-        url = WithProperties("https://dl.dolphin-emu.org/wips/%s-dolphin-%s-%s.dmg", "author", "branchname", "shortrev")
     elif mode == "pr":
         master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest.dmg", "branchname")
         url = WithProperties("https://dl.dolphin-emu.org/prs/%s-dolphin-latest.dmg", "branchname")


### PR DESCRIPTION
The wip builders were removed by https://github.com/dolphin-emu/sadm/commit/336d0e6064679019cfb5720d83b8008e2e0983c9, so these lines do nothing.