### PR TITLE
buildbot: Set minimum macOS to 10.13 High Sierra on Intel builder

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -488,7 +488,7 @@ def make_dolphin_osx_build(mode="normal"):
                            descriptionDone="mkbuilddir",
                            hideStepIf=StepWasSuccessful))
 
-    f.addStep(ShellCommand(command=["cmake", "-GNinja", "-DDISTRIBUTOR=dolphin-emu.org", "-DENCODE_FRAMEDUMPS=OFF", "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12.0", ".."],
+    f.addStep(ShellCommand(command=["cmake", "-GNinja", "-DDISTRIBUTOR=dolphin-emu.org", "-DENCODE_FRAMEDUMPS=OFF", "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13.0", ".."],
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",


### PR DESCRIPTION
Companion PR to dolphin-emu/dolphin#10037.

The Intel builder sets the `CMAKE_OSX_DEPLOYMENT_TARGET` to 10.12 Sierra, so we need to update it here too.