### PR TITLE
buildbot: Add shortrev or branchname to DMG volume name

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -399,12 +399,18 @@ def make_dolphin_osx_universal_build(mode="normal"):
     #                        descriptionDone="sign updater",
     #                        haltOnFailure=True))
 
+    if mode == "normal":
+        volume_name = WithProperties("Dolphin %s", "shortrev")
+    elif mode == "pr":
+        volume_name = WithProperties("Dolphin %s", "branchname")
+    else:
+        volume_name = "Dolphin"
+
     f.addStep(ShellCommand(command=["hdiutil", "create", "dolphin.dmg",
                                     "-format", "UDBZ",
                                     "-fs", "HFS+", # Needed for 7-Zip support
                                     "-srcfolder", "dmg.dir", "-ov",
-                                    "-volname", "Dolphin"],
-                                    #"-volname", "dolphin.dmg"],
+                                    "-volname", volume_name],
                            workdir="build/build",
                            logEnviron=False,
                            description="packaging",


### PR DESCRIPTION
I tried to bisect an issue recently and ended up with many "Dolphin" disks on my Desktop. I couldn't tell which disk contained which version.

This PR makes it so that the name of the volume contains the version number in normal builds ("Dolphin 5.0-12345") or the PR number for PR builds ("Dolphin pr-12345").