### PR TITLE
buildbot: Add support for macOS FifoCI

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -707,6 +707,83 @@ def make_fifoci_linux(type, mode="normal"):
 
     return f
 
+def make_fifoci_osx(type, mode="normal"):
+    # Requirements for a FifoCI macOS buildworker:
+    #  - coreutils package installed with brew
+    #  - python dependencies installed on brew-provided python3
+    #  - ~/dff existing to cache DFF files
+    #  - ~/fifoci pointing to FifoCI Git
+
+    mode = mode.split(",")
+    normal = "normal" in mode
+    pr = "pr" in mode
+
+    f = BuildFactory()
+    f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
+                          progress=True, mode="incremental"))
+
+    f.addStep(ShellCommand(command="cd ~/fifoci && git fetch && git checkout master && git reset --hard origin/master || true",
+                           logEnviron=False,
+                           description="Updating FifoCI",
+                           descriptionDone="FifoCI update"))
+
+    f.addStep(ShellCommand(command=["mkdir", "-p", "build"],
+                           logEnviron=False,
+                           description="mkbuilddir",
+                           descriptionDone="mkbuilddir",
+                           hideStepIf=StepWasSuccessful))
+
+    f.addStep(ShellCommand(command="cmake -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt5 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_MGBA=OFF -GNinja ..",
+                           workdir="build/build",
+                           description="configuring",
+                           descriptionDone="configure",
+                           haltOnFailure=True))
+
+    f.addStep(Compile(command=["ninja"],
+                      workdir="build/build",
+                      description="building",
+                      descriptionDone="build",
+                      haltOnFailure=True))
+
+    url_base = "https://fifo.ci"
+    args = [
+        "--type", type,
+        "--dolphin", "Binaries/",
+        "--rev_base_hash", "$(git rev-parse HEAD)",
+        "--output", "result.zip",
+        "--url_base", url_base,
+        "--dff_dir", "$HOME/dff",
+    ]
+    if normal:
+        args += [
+            "--rev_hash", "$(git rev-parse HEAD)",
+            "--rev_name", "%(shortrev)s",
+            "--rev_submitted", "true",
+        ]
+    elif pr:
+        args += [
+            "--rev_hash", "%(headrev)s",
+            "--rev_name", "%(branchname)s-%(shortrev)s",
+            "--rev_submitted", "false",
+        ]
+    command = "python3 ~/fifoci/runner/runner.py " + " ".join(args)
+    f.addStep(ShellCommand(command=WithProperties(command),
+                           workdir="build/build",
+                           description="gfx testing",
+                           descriptionDone="gfx test",
+                           haltOnFailure=True))
+
+    f.addStep(FileUpload(workersrc="build/result.zip",
+                         masterdest="/tmp/fifoci-%s-result.zip" % type,
+                         mode=0o644))
+
+    f.addStep(MasterShellCommand(command="sudo -u fifoci /home/fifoci/venv/bin/python "
+                                         "/home/fifoci/fifoci/frontend/manage.py import_results "
+                                         "/tmp/fifoci-%s-result.zip" % type,
+                                 description="importing result",
+                                 descriptionDone="result import"))
+
+    return f
 
 def make_lint():
     f = BuildFactory()
@@ -866,6 +943,8 @@ BuildmasterConfig = {
                       factory=make_fifoci_linux("uberogl-lin-radeon")),
         BuilderConfig(name="fifoci-sw-lin-mesa", workernames=["hive"],
                       factory=make_fifoci_linux("sw-lin-mesa")),
+        BuilderConfig(name="fifoci-mvk-osx-m1", workernames=["osx-m1"],
+                      factory=make_fifoci_osx("mvk-osx-m1")),
 
         BuilderConfig(name="pr-fifoci-ogl-lin-mesa", workernames=["hive"],
                       factory=make_fifoci_linux("ogl-lin-mesa", "pr")),
@@ -875,6 +954,8 @@ BuildmasterConfig = {
                       factory=make_fifoci_linux("uberogl-lin-radeon", "pr")),
         BuilderConfig(name="pr-fifoci-sw-lin-mesa", workernames=["hive"],
                       factory=make_fifoci_linux("sw-lin-mesa", "pr")),
+        BuilderConfig(name="pr-fifoci-mvk-osx-m1", workernames=["osx-m1"],
+                      factory=make_fifoci_osx("mvk-osx-m1", "pr")),
 
         BuilderConfig(name="lint", workernames=["ubuntu"],
                       factory=make_lint()),

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -476,6 +476,16 @@ def make_dolphin_osx_universal_build(mode="normal"):
                                       descriptionDone="clean up",
                                       hideStepIf=StepWasSuccessful))
 
+    if mode == "pr":
+        f.addStep(Trigger(schedulerNames=["pr-fifoci-osx"],
+                            copy_properties=["pr_id", "repo", "headrev", "branchname", "shortrev"],
+                            hideStepIf=StepWasSuccessful))
+    else:
+        f.addStep(TriggerIfBranch(schedulerNames=["fifoci-osx"],
+                                    branchList=["master"],
+                                    copy_properties=["shortrev"],
+                                    hideStepIf=StepWasSuccessful))
+
     return f
 
 def make_dolphin_linux_build(mode="normal"):
@@ -873,6 +883,9 @@ BuildmasterConfig = {
                         "fifoci-uberogl-lin-radeon",
                         "fifoci-sw-lin-mesa",
                     ]),
+        Triggerable(name="fifoci-osx", builderNames=[
+                        "fifoci-mvk-osx-m1",
+                    ]),
         Triggerable(name="fifoci-win", builderNames=[
                     ]),
         Triggerable(name="pr-fifoci-lin", builderNames=[
@@ -880,6 +893,9 @@ BuildmasterConfig = {
                         "pr-fifoci-ogl-lin-radeon",
                         "pr-fifoci-uberogl-lin-radeon",
                         "pr-fifoci-sw-lin-mesa",
+                    ]),
+        Triggerable(name="pr-fifoci-osx", builderNames=[
+                        "pr-fifoci-mvk-osx-m1",
                     ]),
         Triggerable(name="pr-fifoci-win", builderNames=[
                     ]),


### PR DESCRIPTION
Based on how Linux FifoCI is triggered.

All the necessary setup has been completed on the build machine. I have also completed a local test run by executing ``runner.py`` manually, and it generated the ``result.zip`` file without issue.