### PR TITLE
buildbot: Codesign macOS binaries with Developer ID certificate and notarize

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -358,18 +358,18 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            descriptionDone="mkbuilddir",
                            hideStepIf=StepWasSuccessful))
 
-    f.addStep(ShellCommand(command=["../BuildMacOSUniversalBinary.py", "-G", "Ninja", "--run_unit_tests"],
+    f.addStep(ShellCommand(command="security unlock-keychain -p $(cat ~/.keychain-password) buildbot.keychain-db",
+                           workdir="build/build",
+                           description="unlocking keychain",
+                           descriptionDone="unlock keychain",
+                           haltOnFailure=True,
+                           hideStepIf=StepWasSuccessful))
+
+    f.addStep(ShellCommand(command=["../BuildMacOSUniversalBinary.py", "-G", "Ninja", "--run_unit_tests", "--codesign", "Developer ID"],
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",
                            haltOnFailure=True))
-
-    # code signing not enabled curently
-    # f.addStep(ShellCommand(command="/build/codesign.sh --deep universal/Dolphin.app",
-    #                        workdir="build/build",
-    #                        description="signing",
-    #                        descriptionDone="sign",
-    #                        haltOnFailure=True))
 
     f.addStep(ShellCommand(command="rm -rf dmg.dir && mkdir dmg.dir",
                            workdir="build/build",
@@ -392,13 +392,6 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            haltOnFailure=True #,hideStepIf=StepWasSuccessful
                            ))
 
-    # code signing not enabled currently
-    # f.addStep(ShellCommand(command=r"/build/codesign.sh --deep universal/Dolphin\ Updater.app; cp -R universal/Dolphin\ Updater.app dmg.dir",
-    #                        workdir="build/build",
-    #                        description="signing updater",
-    #                        descriptionDone="sign updater",
-    #                        haltOnFailure=True))
-
     if mode == "normal":
         volume_name = WithProperties("Dolphin %s", "shortrev")
     elif mode == "pr":
@@ -415,12 +408,29 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            logEnviron=False,
                            description="packaging",
                            descriptionDone="package"))
-    # code signing not enabled currently
-    # f.addStep(ShellCommand(command="/build/codesign.sh --deep dolphin.dmg",
-    #                        workdir="build/build",
-    #                        description="signing dmg",
-    #                        descriptionDone="sign dmg",
-    #                        haltOnFailure=True))
+
+    if mode == "normal":
+        f.addStep(ShellCommand(command=["xcrun", "notarytool", "submit", "dolphin.dmg",
+                                        "--keychain-profile", "NotaryCredentials",
+                                        "--keychain", "~/Library/Keychains/buildbot.keychain-db",
+                                        "--wait"],
+                           workdir="build/build",
+                           description="notarizing",
+                           descriptionDone="notarize",
+                           haltOnFailure=True))
+
+        f.addStep(ShellCommand(command=["xcrun", "stapler", "staple", "dolphin.dmg"],
+                           workdir="build/build",
+                           description="stapling",
+                           descriptionDone="staple",
+                           haltOnFailure=True))
+
+    f.addStep(ShellCommand(command="security lock-keychain buildbot.keychain-db",
+                        workdir="build/build",
+                        description="locking keychain",
+                        descriptionDone="lock keychain",
+                        haltOnFailure=True,
+                        hideStepIf=StepWasSuccessful))
 
     if mode == "normal":
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")


### PR DESCRIPTION
This PR codesigns the Dolphin and Dolphin Updater applications with our new Developer ID certificate, and then notarizes the disk image. The scripts, build keychain, and certificates have already been set up on the machine.

In terms of notarization, all development, beta, and stable builds are submitted to the Apple notary service. PR builds are not notarized. (Apple says that we should limit requests to the notary service to 75 per day, so I chose to not include PR builds given that PRs can be rebuilt several times.)

When a build is submitted to the notary service, ``notarytool`` waits for it to return a result. When it does, we staple the result to the binaries afterwards using ``stapler``. (Apple states that most software takes less than 5 minutes to notarize, and 98% of software completes within 15 minutes. My local tests indicate a notarization time of 2~3 minutes for Dolphin.) An alternate setup would involve just submitting to the notary service and not blocking (no ``--wait``), but this would mean stapling the result to the binary would not be possible, requiring the user's Mac to have an Internet connection to retrieve the notarization result.

More information on the notarization process can be found [here](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow?language=objc).

While I have successfully tested these steps separately in a shell over SSH, the context which the buildbot is running in may not have access to the correct keychain by default. However, I did make a change to the local configuration in an attempt to fix this in advance, so it should just work(tm).