### PR TITLE
ircclient: Wark in red instead of green if the user is not trusted

### DIFF
--- a/central/ircclient.py
+++ b/central/ircclient.py
@@ -32,11 +32,15 @@ class Bot(IRC):
 
     def on_channel_message(self, who, channel, msg):
         direct = msg.startswith(self.cfg.nick)
+        modes = who.user.modes_in(channel)
 
         if direct:
-            self.message(channel, Tags.LtGreen(Tags.Bold('WARK WARK WARK')))
+            trusted = 'o' in modes
+            if trusted:
+                self.message(channel, Tags.BoldLtGreen('WARK WARK WARK'))
+            else:
+                self.message(channel, Tags.BoldRed('WARK WARK WARK'))
 
-        modes = who.user.modes_in(channel)
         evt = events.IRCMessage(str(who), channel, msg, modes, direct)
         events.dispatcher.dispatch('ircclient', evt)
 


### PR DESCRIPTION
Users often forget that they need to be opped to use commands, since irrawaddy gives the same output in either case.

Currently the only commands that exist check if the user is opped:

https://github.com/dolphin-emu/sadm/blob/f6053a71ba792bfeb324abadac505d7db0f58561/central/buildbot.py#L158-L175
https://github.com/dolphin-emu/sadm/blob/38433caf317fafb66c46efdbf6bed03fbf9d21c0/central/admin.py#L11-L18

It might be better to give more detailed information in the commands themselves, but this is still a helpful clue.

This PR is completely untested, but note that [per a doc comment in the Pypeul source](https://pypi.org/project/Pypeul/#files) `BoldRed` and `BoldLtGreen` are legal:

<details>

```python
class Tags:
    '''
    This class is used to represent mIRC-style formatted text

    Here are a few examples of the syntax :

    >>> Tags.Bold('foo') + 'bar'
    ChunkList([<Chunk('foo', bold)>, <Chunk('bar')>])

    >>> Tags.BoldRed('foo') + 'bar'
    ChunkList([<Chunk('foo', fgcolor='red', bold)>, <Chunk('bar')>])

    >>> Tags.UnderlineRed("This is " + Tags.BoldBlue("SPARTAAAAA!!!"))
    ChunkList([<Chunk('This is ', fgcolor='red', underline)>,
        <Chunk('SPARTAAAAA!!!', fgcolor='blue', bold, underline)>])

    >>> Tags.BoldYellowBlue("This text is yellow on a blue background")
    ChunkList([<Chunk('This text is yellow on a blue background',
        fgcolor='yellow', bgcolor='blue', bold)>])

    The first and second color names are respectively foreground and background
    colors.  Other tags may be put in any other place.  The keywords are
    case-insensitive (Tags.boldred("hello") works as well)

    The result is a ChunkList object that will be automatically converted when
    sent over IRC.  str() can also be used to force the conversion

    The following tags are defined : Bold, Underline, Reverse, Reset

    Some notes about nested tags :
        - child tag will inherit the parent's background color, unless it has
          Reset or Uncolor attribute (or another background color)
        - child tag always has priority over the parent :
            Tags.Red(Tags.Blue("...")) will be blue '''
```

</details>