### PR TITLE
buildbot: Add support for creating Steam builds on Windows and macOS

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -155,6 +155,7 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
     debug = "debug" in mode
     pr = "pr" in mode
     fifoci_golden = "fifoci_golden" in mode
+    steam = "steam" in mode
 
     update_platform = {"x64": "win", "ARM64": "win-arm64"}[arch]
 
@@ -166,9 +167,23 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
     env = {"DOLPHIN_BRANCH": branch, "DOLPHIN_DISTRIBUTOR": "dolphin-emu.org"}
     if normal:
         env["DOLPHIN_DEFAULT_UPDATE_TRACK"] = "beta"
-    f.addStep(Compile(command=["msbuild.exe", "/v:m", "/p:Platform=%s" % arch,
-                               "/p:Configuration=%s" % build_type,
-                               "dolphin-emu.sln"],
+
+    build_command = [
+        "msbuild.exe",
+        "/v:m",
+        "/p:Platform=%s" % arch,
+        "/p:Configuration=%s" % build_type,
+    ]
+
+    if steam:
+        build_command += [
+            "/p:Steam=true",
+            "/p:AutoUpdate=false"
+        ]
+
+    build_command += ["dolphin-emu.sln"]
+
+    f.addStep(Compile(command=build_command,
                       env=env,
                       workdir="build/Source",
                       description="building",
@@ -206,25 +221,32 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
     else:
         fn_arch = arch
 
-    if "normal" in mode:
-        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
-        url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
-    elif pr:
-        master_filename = WithProperties("/srv/http/dl/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
-        url = WithProperties("https://dl.dolphin-emu.org/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
-    else:
-        master_filename = url = ""
+    if normal or pr:
+        if normal:
+            master_filename = WithProperties("/srv/http/dl/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
+            url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%%s-%%s-%s.7z" % fn_arch, "branchname", "shortrev")
+        elif pr:
+            master_filename = WithProperties("/srv/http/dl/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
+            url = WithProperties("https://dl.dolphin-emu.org/prs/%%s-dolphin-latest-%s.7z" % fn_arch, "branchname")
+        else:
+            master_filename = url = ""
 
-    master_filename, url = map(get_sharded_dl_path, (master_filename, url))
+        master_filename, url = map(get_sharded_dl_path, (master_filename, url))
 
-    f.addStep(SetProperty(property="build_url",
-                          value=url,
-                          hideStepIf=StepWasSuccessful))
+        f.addStep(SetProperty(property="build_url",
+                            value=url,
+                            hideStepIf=StepWasSuccessful))
 
-    if master_filename and url:
-        f.addSteps(ReliableFileUpload(workersrc=out_filename,
-                                      masterdest=master_filename,
-                                      url=url, keepstamp=True, mode=0o644))
+        if master_filename and url:
+            f.addSteps(ReliableFileUpload(workersrc=out_filename,
+                                        masterdest=master_filename,
+                                        url=url, keepstamp=True, mode=0o644))
+    elif steam:
+        master_filename = WithProperties("/tmp/steam/%s/win.7z", "revision")
+
+        f.addStep(FileUpload(workersrc=out_filename,
+                             masterdest=master_filename,
+                             keepstamp=True, mode=0o644))
 
     if fifoci_golden:
         if pr:

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -345,6 +345,10 @@ def make_fifoci_win(type, mode="normal"):
 def make_dolphin_osx_universal_build(mode="normal"):
     f = BuildFactory()
 
+    mode = mode.split(",")
+    normal = "normal" in mode
+    pr = "pr" in mode
+
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
 
@@ -388,9 +392,9 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            haltOnFailure=True #,hideStepIf=StepWasSuccessful
                            ))
 
-    if mode == "normal":
+    if normal:
         volume_name = WithProperties("Dolphin %s", "shortrev")
-    elif mode == "pr":
+    elif pr:
         volume_name = WithProperties("Dolphin %s", "branchname")
     else:
         volume_name = "Dolphin"
@@ -405,7 +409,7 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            description="packaging",
                            descriptionDone="package"))
 
-    if mode == "normal":
+    if normal:
         f.addStep(ShellCommand(command=["xcrun", "notarytool", "submit", "dolphin.dmg",
                                         "--keychain-profile", "NotaryCredentials",
                                         "--keychain", "~/Library/Keychains/buildbot.keychain-db",
@@ -428,10 +432,10 @@ def make_dolphin_osx_universal_build(mode="normal"):
                         haltOnFailure=True,
                         hideStepIf=StepWasSuccessful))
 
-    if mode == "normal":
+    if normal:
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
         url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
-    elif mode == "pr":
+    elif pr:
         master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest-universal.dmg", "branchname")
         url = WithProperties("https://dl.dolphin-emu.org/prs/%s-dolphin-latest-universal.dmg", "branchname")
     else:
@@ -444,8 +448,7 @@ def make_dolphin_osx_universal_build(mode="normal"):
                                       masterdest=master_filename,
                                       url=url, keepstamp=True, mode=0o644))
 
-    if mode == "normal":
-
+    if normal:
          f.addStep(MasterShellCommand(command="/home/buildbot/bin/send_build.py",
                                         env={
                                             "BRANCH": WithProperties("%s", "branchname"),

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -848,6 +848,42 @@ def make_fifoci_osx(type, mode="normal"):
 
     return f
 
+def make_steam_build():
+    f = BuildFactory()
+
+    work_dir = WithProperties("/tmp/steam/%s", "revision")
+
+    f.addStep(MasterShellCommand(command=['rm', '-rf' , work_dir],
+                                 description="deleting work dir",
+                                 descriptionDone="delete work dir",
+                                 hideStepIf=StepWasSuccessful,
+                                 haltOnFailure=True))
+    
+    f.addStep(MasterShellCommand(command=['mkdir', '-p', work_dir],
+                                 description="creating work dir",
+                                 descriptionDone="create work dir",
+                                 hideStepIf=StepWasSuccessful,
+                                 haltOnFailure=True))
+
+    f.addStep(Trigger(schedulerNames=["release-steam-all"],
+                      copy_properties=["pr_id", "repo", "headrev", "branchname", "shortrev"],
+                      waitForFinish=True))
+    
+    f.addStep(MasterShellCommand(command=['/home/buildbot/bin/steam_upload.sh',
+                                        work_dir,
+                                        WithProperties("%s", "shortrev")],
+                                 description="uploading content",
+                                 descriptionDone="upload content",
+                                 haltOnFailure=True))
+
+    f.addStep(MasterShellCommand(command=["rm", '-rf', work_dir],
+                                 description="cleaning up",
+                                 descriptionDone="clean up",
+                                 hideStepIf=StepWasSuccessful,
+                                 alwaysRun=True))
+
+    return f
+
 def make_lint():
     f = BuildFactory()
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
@@ -874,6 +910,8 @@ ubu64_release = AnyBranchScheduler(name="ubu64-release", builderNames=["release-
 android_release = Dependent(name="android-release", upstream=ubu64_release, builderNames=["release-android"])
 
 freebsd_release = AnyBranchScheduler(name="freebsd-release", builderNames=["release-freebsd-x64"])
+
+steam_release = AnyBranchScheduler(name="steam-release", builderNames=["release-steam"])
 
 lint_release = AnyBranchScheduler(name="lint-release", builderNames=["lint"])
 
@@ -930,6 +968,12 @@ BuildmasterConfig = {
         ubu64_release,
         android_release,
         freebsd_release,
+        steam_release,
+
+        Triggerable(name="release-steam-all", builderNames=[
+                        "release-steam-win-x64",
+                        "release-steam-osx-universal",
+                    ]),
 
         Triggerable(name="fifoci-lin", builderNames=[
                         "fifoci-ogl-lin-mesa",
@@ -987,6 +1031,13 @@ BuildmasterConfig = {
                       factory=make_android_package()),
         BuilderConfig(name="release-freebsd-x64", workernames=["freebsd"],
                       factory=make_dolphin_freebsd_build()),
+
+        BuilderConfig(name="release-steam", workernames["ubuntu"],
+                      factory=make_steam_build()),
+        BuilderConfig(name="release-steam-win-x64", workernames=["windows"],
+                      factory=make_dolphin_win_build("Release", "x64", "steam")),
+        BuilderConfig(name="release-steam-osx-universal", workernames=["osx-m1"],
+                      factory=make_dolphin_osx_universal_build("steam")),
 
         BuilderConfig(name="pr-win-x64", workernames=["windows"],
                       factory=make_dolphin_win_build("Release", "x64", "pr,fifoci_golden")),

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -348,6 +348,7 @@ def make_dolphin_osx_universal_build(mode="normal"):
     mode = mode.split(",")
     normal = "normal" in mode
     pr = "pr" in mode
+    steam = "steam" in mode
 
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
@@ -365,7 +366,20 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            haltOnFailure=True,
                            hideStepIf=StepWasSuccessful))
 
-    f.addStep(ShellCommand(command=["../BuildMacOSUniversalBinary.py", "-G", "Ninja", "--run_unit_tests", "--codesign", "Developer ID"],
+    command = [
+       "../BuildMacOSUniversalBinary.py",
+       "-G", "Ninja",
+       "--run_unit_tests",
+       "--codesign", "Developer ID" 
+    ]
+
+    if steam:
+        command += [
+            "--steam",
+            "--no-autoupdate"
+        ]
+
+    f.addStep(ShellCommand(command=command,
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",
@@ -385,12 +399,13 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            haltOnFailure=True,
                            hideStepIf=StepWasSuccessful))
 
-    f.addStep(ShellCommand(command="cp -R universal/Dolphin\ Updater.app dmg.dir",
-                           workdir="build/build",
-                           description="creating tmp dir",
-                           descriptionDone="create tmp dir",
-                           haltOnFailure=True #,hideStepIf=StepWasSuccessful
-                           ))
+    if steam:
+        f.addStep(ShellCommand(command="cp -R universal/Dolphin\ Updater.app dmg.dir",
+                               workdir="build/build",
+                               description="creating tmp dir",
+                               descriptionDone="create tmp dir",
+                               haltOnFailure=True,
+                               hideStepIf=StepWasSuccessful))
 
     if normal:
         volume_name = WithProperties("Dolphin %s", "shortrev")
@@ -409,7 +424,7 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            description="packaging",
                            descriptionDone="package"))
 
-    if normal:
+    if normal or steam:
         f.addStep(ShellCommand(command=["xcrun", "notarytool", "submit", "dolphin.dmg",
                                         "--keychain-profile", "NotaryCredentials",
                                         "--keychain", "~/Library/Keychains/buildbot.keychain-db",
@@ -431,22 +446,29 @@ def make_dolphin_osx_universal_build(mode="normal"):
                         descriptionDone="lock keychain",
                         haltOnFailure=True,
                         hideStepIf=StepWasSuccessful))
+    
+    if normal or pr:
+        if normal:
+            master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
+            url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
+        elif pr:
+            master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest-universal.dmg", "branchname")
+            url = WithProperties("https://dl.dolphin-emu.org/prs/%s-dolphin-latest-universal.dmg", "branchname")
+        else:
+            master_filename = url = ""
 
-    if normal:
-        master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
-        url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s-universal.dmg", "branchname", "shortrev")
-    elif pr:
-        master_filename = WithProperties("/srv/http/dl/prs/%s-dolphin-latest-universal.dmg", "branchname")
-        url = WithProperties("https://dl.dolphin-emu.org/prs/%s-dolphin-latest-universal.dmg", "branchname")
-    else:
-        master_filename = url = ""
+        master_filename, url = map(get_sharded_dl_path, (master_filename, url))
 
-    master_filename, url = map(get_sharded_dl_path, (master_filename, url))
+        if master_filename and url:
+            f.addSteps(ReliableFileUpload(workersrc="build/dolphin.dmg",
+                                        masterdest=master_filename,
+                                        url=url, keepstamp=True, mode=0o644))
+    elif steam:
+        master_filename = WithProperties("/tmp/steam/%s/mac.dmg", "revision")
 
-    if master_filename and url:
-         f.addSteps(ReliableFileUpload(workersrc="build/dolphin.dmg",
-                                      masterdest=master_filename,
-                                      url=url, keepstamp=True, mode=0o644))
+        f.addStep(FileUpload(workersrc="build/dolphin.dmg",
+                             masterdest=master_filename,
+                             keepstamp=True, mode=0o644))
 
     if normal:
          f.addStep(MasterShellCommand(command="/home/buildbot/bin/send_build.py",

--- a/buildbot/steam_build_script.vdf
+++ b/buildbot/steam_build_script.vdf
@@ -1,0 +1,34 @@
+"AppBuild"
+{
+    "AppID" "1941680"
+    "Desc" "DOLPHIN_BUILD_NUMBER"
+
+    "ContentRoot" "content"
+    "BuildOutput" "output"
+
+    "Depots"
+    {
+        "1941682" // Windows
+        {
+            "FileMapping"
+            {
+                "LocalPath" "win/Dolphin-x64/*"
+                "DepotPath" "."
+                "recursive" "1"
+            }
+
+            "FileExclusion" "win/Dolphin-x64/Updater.exe"
+        }
+        "1941683" // macOS
+        {
+            "FileMapping"
+            {
+                "LocalPath" "mac/*"
+                "DepotPath" "."
+                "recursive" "1"
+            }
+
+            "FileExclusion" "*.DS_Store"
+        }
+    }
+}

--- a/buildbot/steam_upload.sh
+++ b/buildbot/steam_upload.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+cd $1
+
+mkdir content
+
+# Extract Windows and Linux archives to subdirectories within the content folder.
+7z x *.7z -ocontent/*
+
+# Extract the macOS DMG and do some corrections to remove useless folders.
+mkdir content/mac
+7z x mac.dmg -omac_tmp
+mv mac_tmp/Dolphin/Dolphin.app content/mac/
+
+# Copy the .vdf and add the build number to it.
+cp /home/buildbot/bin/steam_build_script.vdf .
+sed -i "s/DOLPHIN_BUILD_NUMBER/$2/" steam_build_script.vdf
+
+# Upload to Steam.
+# TODO: path to Steamworks SDK and build account username
+/path/to/sdk/tools/ContentBuilder/builder_linux/steamcmd.sh +login xyz +run_app_build $1/steam_build_script.vdf +quit


### PR DESCRIPTION
Here's how this works:

* The `steam-release` scheduler triggers the `release-steam` job.
* `release-steam` creates a temporary directory - `/tmp/steam/<revision>`. This directory will contain the resulting builds (uploaded from the build machines) and serve as a working directory for `steamcmd`.
* `release-steam` job then triggers the `release-steam-all` scheduler, which in turn triggers the `release-steam-win-x64` and `release-steam-osx-universal` builders, and waits for all of them to finish.
* Once those builders have finished, the `steam_upload.sh` script is ran.
* The `steam_upload.sh` script extracts the builds, and uploads them to Steam using the SteamPipe build script.

Note to actually make a build "live" to users, it is necessary to go to the Steamworks partner web page and manually set it as live there. There does not seem to be an API for this.

There is no support for pushing to the Linux depot. A buildbot worker needs to be set up within the Steam runtime (`sniper`, *not* `scout`) so a builder can be added for it.

TODO:

- [ ] The Steamworks SDK (downloadable [here](https://partner.steamgames.com/downloads/list), login required) needs to be set up on the build master.
    * The command `tools/ContentBuilder/builder_linux/steamcmd.sh +login <username> <password>` must be ran at least once to cache credentials and to authenticate with Steam Guard.
    * [Valve recommends creating an account specifically for this purpose](https://partner.steamgames.com/doc/sdk/uploading#Build_Account).
- [x] This PR depends on dolphin-emu/dolphin#10814 and dolphin-emu/dolphin#10780.