### PR TITLE
buildbot: add tarball builder

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -147,6 +147,47 @@ def prioritize_builders(buildmaster, builders):
     return builders
 
 
+def make_dolphin_tarball(mode="normal"):
+    f = BuildFactory()
+
+    f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
+                          progress=True, mode="incremental"))
+
+    out_filename = WithProperties("dolphin-%s-%s.tar.xz", "branchname", "shortrev")
+    f.addStep(ShellCommand(command=["tar", "--exclude-vcs", "-cJf", out_filename, "*"],
+                           logEnviron=False,
+                           description="compressing",
+                           descriptionDone="compression",
+                           hideStepIf=StepWasSuccessful))
+
+    master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.tar.xz", "branchname", "shortrev")
+    url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s.tar.xz", "branchname", "shortrev")
+
+    master_filename, url = map(get_sharded_dl_path, (master_filename, url))
+
+    f.addSteps(ReliableFileUpload(workersrc=out_filename,
+                                  masterdest=master_filename,
+                                  url=url, keepstamp=True, mode=0o644))
+
+    if mode == "normal":
+        f.addStep(MasterShellCommand(command="/home/buildbot/bin/send_build.py",
+                                     env={
+                                         "BRANCH": WithProperties("%s", "branchname"),
+                                         "SHORTREV": WithProperties("%s", "shortrev"),
+                                         "HASH": WithProperties("%s", "revision"),
+                                         "AUTHOR": WithProperties("%s", "author"),
+                                         "DESCRIPTION": WithProperties("%s", "description"),
+                                         "TARGET_SYSTEM": "Source Code",
+                                         "USER_OS_MATCHER": "tarball",
+                                         "BUILD_URL": url,
+                                     },
+                                     description="notifying website",
+                                     descriptionDone="website notice"))
+
+    return f
+
+
+
 def make_dolphin_win_build(build_type, arch, mode="normal"):
     f = BuildFactory()
 
@@ -818,6 +859,8 @@ android_release = Dependent(name="android-release", upstream=ubu64_release, buil
 
 freebsd_release = AnyBranchScheduler(name="freebsd-release", builderNames=["release-freebsd-x64"])
 
+tarball_release = AnyBranchScheduler(name="tarball-release", builderNames=["release-tarball"])
+
 lint_release = AnyBranchScheduler(name="lint-release", builderNames=["lint"])
 
 BuildmasterConfig = {
@@ -873,6 +916,7 @@ BuildmasterConfig = {
         ubu64_release,
         android_release,
         freebsd_release,
+        tarball_release,
 
         Triggerable(name="fifoci-lin", builderNames=[
                         "fifoci-ogl-lin-mesa",
@@ -930,6 +974,8 @@ BuildmasterConfig = {
                       factory=make_android_package()),
         BuilderConfig(name="release-freebsd-x64", workernames=["freebsd"],
                       factory=make_dolphin_freebsd_build()),
+        BuilderConfig(name="release-tarball", workernames=["debian"],
+                      factory=make_dolphin_tarball()),
 
         BuilderConfig(name="pr-win-x64", workernames=["windows"],
                       factory=make_dolphin_win_build("Release", "x64", "pr,fifoci_golden")),


### PR DESCRIPTION
I'm attempting to resolve #158.

This produces a tar.xz file that is around 100MB. Currently all builds together add up to around 75MB so I understand if this in undesirable.

I have no experience with buildbot, this code is untested beyond running `buildbot checkconfig`.

I think the tag or branch approach described in #158 is a better route, however I'm not sure where in the sadm codebase that would be implemented.