### PR TITLE
Revert "buildbot: temporarily disable macOS FifoCI until the random diffs are fixed

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -482,6 +482,16 @@ def make_dolphin_osx_universal_build(mode="normal"):
                                       descriptionDone="clean up",
                                       hideStepIf=StepWasSuccessful))
 
+    if mode == "pr":
+        f.addStep(Trigger(schedulerNames=["pr-fifoci-osx"],
+                            copy_properties=["pr_id", "repo", "headrev", "branchname", "shortrev"],
+                            hideStepIf=StepWasSuccessful))
+    else:
+        f.addStep(TriggerIfBranch(schedulerNames=["fifoci-osx"],
+                                    branchList=["master"],
+                                    copy_properties=["shortrev"],
+                                    hideStepIf=StepWasSuccessful))
+
     return f
 
 def make_dolphin_linux_build(mode="normal"):


### PR DESCRIPTION
This reverts commit 1c7f931fca917f7cbaf81d860ea2b7b6363e26f1.

I think we should probably add a Metal runner too so we can test that backend, but let's see if this works first.