### PR TITLE
buildbot: Automatically generate baseline profiles

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -544,6 +544,13 @@ def make_android_package(mode="normal"):
                               haltOnFailure=False))
 
     if mode == "normal":
+        f.addStep(ShellCommand(command="./gradlew :benchmark:pixel6Api31BenchmarkAndroidTest "
+                                   "-P android.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile",
+                              workdir="build/Source/Android",
+                              description="Generate baseline profile",
+                              descriptionDone="Generate baseline profile",
+                              haltOnFailure=True))
+
         f.addStep(ShellCommand(command="./gradlew assembleRelease",
                                workdir="build/Source/Android",
                                description="Gradle",


### PR DESCRIPTION
Continuation of #165 
This is likely the best way of implementing the generation step given that there isn't a reasonable way of running a gradle task from another module with additional arguments. This becomes worse if we try to start another gradle instance from the app module where issues like java home directories and cross platform building become more of an issue.