### PR TITLE
buildbot: Clean android app build files before each build

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -653,8 +653,8 @@ def make_android_package(mode="normal"):
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, mode="incremental"))
 
-    f.addStep(ShellCommand(command="find . -name 'android_gradle_build.json' -delete",
-                              workdir="build/Source/Android/app/.cxx",
+    f.addStep(ShellCommand(command="rm -rf .cxx/ && rm -rf build/",
+                              workdir="build/Source/Android/app",
                               description="Workaround for https://issuetracker.google.com/issues/232060576?pli=1%22",
                               descriptionDone="Workaround for https://issuetracker.google.com/issues/232060576?pli=1%22",
                               haltOnFailure=False))


### PR DESCRIPTION
Since the android builder keeps giving us problems when compiling the android gui, I'm starting to suspect that the workaround for gradle is causing problems. To help alleviate this I'm gonna try deleting all the build files for the app module so we avoid issues between PRs.