### PR TITLE
buildbot: Enable SDL on Steam runtime builds

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -609,7 +609,8 @@ def make_dolphin_linux_steamrt_build(mode="normal"):
         "-DSTEAM=ON",
         "-DENABLE_AUTOUPDATE=OFF",
         "-DENABLE_EVDEV=OFF",
-        "-DENABLE_LLVM=OFF"
+        "-DENABLE_LLVM=OFF",
+        "-DENABLE_SDL=ON"
     ]
 
     f.addStep(ShellCommand(command=cmake_cmd,


### PR DESCRIPTION
While the Steam runtime doesn't ship with libevdev, it *does* ship with a copy of SDL2. We need to enable our SDL input backend so that controllers actually work.

Forgot to enable this in the last PR.