### PR TITLE
android buildbot: Generate baseline profiles on release build

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -661,6 +661,14 @@ def make_android_package(mode="normal"):
                               haltOnFailure=False))
 
     if mode == "normal":
+        f.addStep(ShellCommand(command="./gradlew :benchmark:pixel6Api31BenchmarkAndroidTest "
+                                       "-P android.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile "
+                                       "-P android.testoptions.manageddevices.emulator.gpu=swiftshader_indirect",
+                              workdir="build/Source/Android",
+                              description="Baseline Profile",
+                              descriptionDone="Baseline Profile",
+                              haltOnFailure=False))
+
         f.addStep(ShellCommand(command="./gradlew assembleRelease",
                                workdir="build/Source/Android",
                                description="Gradle",


### PR DESCRIPTION
Continuation of #165

Additionally, KVM will need to be enabled on the android container before this is merged.