### PR TITLE
msbuild UnitTests: only build UnitTests

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -187,9 +187,9 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
                       haltOnFailure=True))
 
     if arch == 'x64':
-        f.addStep(Test(command=build_command + ["/p:RunUnitTests=true", "dolphin-emu.sln"],
+        f.addStep(Test(command=build_command + ["/p:RunUnitTests=true", "UnitTests.vcxproj"],
                         env=env,
-                        workdir="build/Source",
+                        workdir="build/Source/UnitTests",
                         description="testing",
                         descriptionDone="test",
                         haltOnFailure=True))


### PR DESCRIPTION
In the event re-running with RunUnitTests=true actually causes compilation, limit the targets to only UnitTests project and dependencies.