### PR TITLE
android-buildbot: Generate Android App Bundles

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -607,13 +607,23 @@ def make_android_package(mode="normal"):
 
         f.addStep(ShellCommand(command="./gradlew assembleRelease",
                                workdir="build/Source/Android",
-                               description="Gradle",
-                               descriptionDone="Gradle",
+                               description="Gradle APK",
+                               descriptionDone="Gradle APK",
+                               haltOnFailure=True))
+
+        f.addStep(ShellCommand(command="./gradlew bundleRelease",
+                               workdir="build/Source/Android",
+                               description="Gradle Bundle",
+                               descriptionDone="Gradle Bundle",
                                haltOnFailure=True))
 
         source_filename = "Source/Android/app/build/outputs/apk/release/app-release-unsigned.apk"
         master_filename = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
         url = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s.apk", "branchname", "shortrev")
+
+        source_filename_play = "Source/Android/app/build/outputs/bundle/release/app-release.aab"
+        master_filename_play = WithProperties("/srv/http/dl/builds/dolphin-%s-%s.aab", "branchname", "shortrev")
+        url_play = WithProperties("https://dl.dolphin-emu.org/builds/dolphin-%s-%s.aab", "branchname", "shortrev")
 
     else:
         f.addStep(ShellCommand(command="./gradlew assembleDebug",
@@ -640,10 +650,28 @@ def make_android_package(mode="normal"):
                                                 "--ks-key-alias", "mykey",
                                                 "--ks-pass", "file:/home/buildbot/dolphin-release.keystore.pass",
                                                 tmpdest],
-                                       description="Signing release build",
-                                       descriptionDone="Signing release build",
+                                       description="Signing release APK",
+                                       descriptionDone="Signing release APK",
                                        haltOnFailure=True)
         steps.insert(2, apksigner)
+
+        master_filename_play, url_play = map(get_sharded_dl_path, (master_filename_play, url_play))
+
+        playupload = ReliableFileUpload(workersrc=source_filename_play,
+                                       masterdest=master_filename_play,
+                                       url=url_play, keepstamp=True, mode=0o644)
+
+        tmpdest = util.Transform(lambda p: os.path.join('/tmp', os.path.basename(p)), master_filename_play)
+        jarsigner_cmd = util.Transform(lambda p: ("jarsigner " 
+                                                  "-keystore /home/buildbot/dolphin-release.keystore "
+                                                  "-storepass $(cat /home/buildbot/dolphin-release.keystore.pass) "
+                                                  "%s mykey") % p, tmpdest)
+        jarsigner = MasterShellCommand(command=jarsigner_cmd,
+                                       description="Signing release AAB",
+                                       descriptionDone="Signing release AAB",
+                                       haltOnFailure=True)
+        playupload.insert(2, jarsigner)
+        steps += playupload
 
     f.addSteps(steps)
 


### PR DESCRIPTION
This *should* generate and upload android app bundles to the website.

Just some rationale around app bundles
- Reduced download size
- Debug symbols are shipped to the play console so we can actually read the crash logs