### PR TITLE
buildbot: Change Steam target branch to "development"

### DIFF
--- a/buildbot/steampipe_app_build.vdf
+++ b/buildbot/steampipe_app_build.vdf
@@ -2,7 +2,7 @@
 {
     "AppID" "1941680"
     "Desc" "DOLPHIN_BUILD_NUMBER"
-    "SetLive" "dev-sniper"
+    "SetLive" "development"
 
     "ContentRoot" "content"
     "BuildOutput" "output"


### PR DESCRIPTION
This new branch name should be more clear for users than `dev-sniper`.