### PR TITLE
buildbot: Set distributor to Steam on Steam builds

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -318,7 +318,8 @@ def make_dolphin_osx_universal_build(mode="normal"):
        "../BuildMacOSUniversalBinary.py",
        "-G", "Ninja",
        "--run_unit_tests",
-       "--codesign", "Developer ID" 
+       "--codesign", "Developer ID",
+       "--distributor", "dolphin-emu.org"
     ]
 
     if steam:

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -163,8 +163,13 @@ def make_dolphin_win_build(build_type, arch, mode="normal"):
                           progress=True, mode="incremental"))
     f.addStep(RemoveDirectory(dir="build/Binary", hideStepIf=StepWasSuccessful))
 
+    if steam:
+        distributor = "Steam"
+    else:
+        distributor = "dolphin-emu.org"
+
     branch = WithProperties("%s", "branchname")
-    env = {"DOLPHIN_BRANCH": branch, "DOLPHIN_DISTRIBUTOR": "dolphin-emu.org"}
+    env = {"DOLPHIN_BRANCH": branch, "DOLPHIN_DISTRIBUTOR": distributor}
     if normal:
         env["DOLPHIN_DEFAULT_UPDATE_TRACK"] = "beta"
     
@@ -314,12 +319,17 @@ def make_dolphin_osx_universal_build(mode="normal"):
                            haltOnFailure=True,
                            hideStepIf=StepWasSuccessful))
     
+    if steam:
+        distributor = "Steam"
+    else:
+        distributor = "dolphin-emu.org"
+
     command = [
        "../BuildMacOSUniversalBinary.py",
        "-G", "Ninja",
        "--run_unit_tests",
        "--codesign", "Developer ID",
-       "--distributor", "dolphin-emu.org"
+       "--distributor", distributor
     ]
 
     if steam:
@@ -547,7 +557,8 @@ def make_dolphin_linux_steamrt_build(mode="normal"):
         "-DENABLE_AUTOUPDATE=OFF",
         "-DENABLE_EVDEV=OFF",
         "-DENABLE_LLVM=OFF",
-        "-DENABLE_SDL=ON"
+        "-DENABLE_SDL=ON",
+        "-DDISTRIBUTOR=Steam"
     ]
 
     f.addStep(ShellCommand(command=cmake_cmd,


### PR DESCRIPTION
This also resolves the issue where macOS universal builds did not have their distributor set.