### PR TITLE
ubuntu/debian: qt5 -> qt6

### DIFF
--- a/containers/debian-builder/Dockerfile
+++ b/containers/debian-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye-backports
 
 RUN apt update
 
@@ -9,9 +9,8 @@ RUN apt install -y wget unzip
 RUN apt install -y \
   build-essential git cmake ffmpeg libavcodec-dev libavformat-dev \
   libavutil-dev libswscale-dev libevdev-dev libudev-dev libxrandr-dev \
-  libxi-dev libpangocairo-1.0-0 qtbase5-dev qtchooser qt5-qmake \
-  qtbase5-dev-tools qtbase5-private-dev libbluetooth-dev libasound2-dev \
-  libpulse-dev
+  libxi-dev libpangocairo-1.0-0 qt6-base-dev qt6-base-private-dev \
+  libbluetooth-dev libasound2-dev libpulse-dev
 
 # Buildbot worker dependencies
 RUN apt install -y ninja-build buildbot-worker

--- a/containers/ubuntu-lts-builder/Dockerfile
+++ b/containers/ubuntu-lts-builder/Dockerfile
@@ -9,9 +9,8 @@ RUN apt install -y wget unzip
 RUN apt install -y \
   build-essential git cmake ffmpeg libavcodec-dev libavformat-dev \
   libavutil-dev libswscale-dev libevdev-dev libudev-dev libxrandr-dev \
-  libxi-dev libpangocairo-1.0-0 qtbase5-dev qtchooser qt5-qmake \
-  qtbase5-dev-tools qtbase5-private-dev libbluetooth-dev libasound2-dev \
-  libpulse-dev
+  libxi-dev libpangocairo-1.0-0 qt6-base-dev qt6-base-private-dev \
+  libbluetooth-dev libasound2-dev libpulse-dev
 
 # Android build dependencies
 RUN apt install -y openjdk-11-jdk-headless


### PR DESCRIPTION
tested locally on ubuntu 22.04.2

note qt6-base-private-dev is only required for `<qpa/qplatformnativeinterface.h>` so maybe we should rethink if that is really needed: https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/DolphinQt/MainWindow.cpp#L33