### PR TITLE
ubuntu-lts-builder: Install Java 17 for Android

### DIFF
--- a/containers/ubuntu-lts-builder/Dockerfile
+++ b/containers/ubuntu-lts-builder/Dockerfile
@@ -13,7 +13,7 @@ RUN apt install -y \
   libqt6svg6-dev libbluetooth-dev libasound2-dev libpulse-dev libgl1-mesa-dev
 
 # Android build dependencies
-RUN apt install -y openjdk-11-jdk-headless
+RUN apt install -y openjdk-11-jdk-headless openjdk-17-jdk-headless
 
 # Buildbot worker dependencies
 RUN apt install -y ninja-build buildbot-worker clang-format-12 clang-format-13


### PR DESCRIPTION
Android builds will fail when we update to AGP 8.0 which requires Java 17