### PR TITLE
Ubuntu LTS Builder: Install clang-format-15

### DIFF
--- a/containers/ubuntu-lts-builder/Dockerfile
+++ b/containers/ubuntu-lts-builder/Dockerfile
@@ -16,7 +16,7 @@ RUN apt install -y \
 RUN apt install -y openjdk-11-jdk-headless openjdk-17-jdk-headless
 
 # Buildbot worker dependencies
-RUN apt install -y ninja-build buildbot-worker clang-format-12 clang-format-13
+RUN apt install -y ninja-build buildbot-worker clang-format-12 clang-format-13 clang-format-15
 
 # Android Studio setup (for Java linting)
 RUN cd / && \


### PR DESCRIPTION
This is prep for the lint buildbot; clang-format-15 introduces full formatting options for C++20 requires clauses.

Ubuntu LTS 22.04 and Debian stable (bookworm) both offer this release of clang-format
https://packages.ubuntu.com/search?keywords=clang-format&searchon=names&suite=all&section=all
https://packages.debian.org/search?keywords=clang-format&searchon=names&suite=stable&section=all