### PR TITLE
Re-enable incremental Android builds

### DIFF
--- a/roles/buildbot/etc/master.cfg
+++ b/roles/buildbot/etc/master.cfg
@@ -789,12 +789,6 @@ def make_android_package(mode="normal"):
     f.addStep(GitNoBranch(repourl="https://github.com/dolphin-emu/dolphin.git",
                           progress=True, tags=True, mode="incremental"))
 
-    f.addStep(ShellCommand(command="rm -rf .cxx/ && rm -rf build/",
-                              workdir="build/Source/Android/app",
-                              description="Workaround for https://issuetracker.google.com/issues/232060576?pli=1%22",
-                              descriptionDone="Workaround for https://issuetracker.google.com/issues/232060576?pli=1%22",
-                              haltOnFailure=False))
-
     if normal or release:
         f.addStep(ShellCommand(command="./gradlew :app:generateReleaseBaselineProfile "
                                        "-P android.testoptions.manageddevices.emulator.gpu=swiftshader_indirect",


### PR DESCRIPTION
We disabled incremental Android builds in PR #175 to work around https://issuetracker.google.com/issues/232060576. Google has now reported that this issue is fixed in AGP 8.3.0 and newer, which we updated to one year ago in https://github.com/dolphin-emu/dolphin/commit/5beb1369928f00bdcd3968da4218a9a48b14c962.