### PR TITLE
buildbot: Enable NoGUI for FifoCI

### DIFF
--- a/roles/buildbot/etc/master.cfg
+++ b/roles/buildbot/etc/master.cfg
@@ -1029,7 +1029,7 @@ def make_fifoci_linux(type, mode="normal"):
                            descriptionDone="mkbuilddir",
                            hideStepIf=StepWasSuccessful))
 
-    f.addStep(ShellCommand(command="cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/prefix -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_QT=OFF -DENABLE_EVDEV=OFF -GNinja ..",
+    f.addStep(ShellCommand(command="cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/prefix -DENABLE_NOGUI=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_QT=OFF -DENABLE_EVDEV=OFF -GNinja ..",
                            workdir="build/build",
                            description="configuring",
                            descriptionDone="configure",
@@ -1132,6 +1132,7 @@ def make_fifoci_osx(type, mode="normal"):
         "-G", "Ninja",
         WithProperties("-DCMAKE_PREFIX_PATH=%s/qt/latest/universal", "builddir"),
         "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+        "-DENABLE_NOGUI=ON",
         "-DUSE_MGBA=OFF",
         ".."
     ]


### PR DESCRIPTION
FifoCI invokes `dolphin-emu-nogui`. Explicitly enable it. 